### PR TITLE
Adding copy/paste to vtkQtMatrixDialog

### DIFF
--- a/IbisHardware/tracker.cpp
+++ b/IbisHardware/tracker.cpp
@@ -29,7 +29,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 #include <QList>
 #include <QFileInfo>
-#include <QMessageBox>
 
 ObjectSerializationMacro( Tracker );
 ObjectSerializationMacro( ToolDescription );

--- a/IbisHardware/trackersettingsdialog.h
+++ b/IbisHardware/trackersettingsdialog.h
@@ -13,7 +13,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 #include "ui_trackersettingsdialog.h"
 
-class vtkQtMatrixDialog;
 class Tracker;
 
 class TrackerSettingsDialog : public QWidget, public Ui::TrackerSettingsDialog

--- a/IbisHardware/videosettingsdialog.cpp
+++ b/IbisHardware/videosettingsdialog.cpp
@@ -20,7 +20,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <qspinbox.h>
 #include <qsplitter.h>
 #include <qlayout.h>
-#include <QMessageBox>
 #include "videoviewdialog.h"
 #include "automaticgui.h"
 #include "vtkVideoSource2.h"

--- a/IbisLib/gui/aboutbicigns.ui
+++ b/IbisLib/gui/aboutbicigns.ui
@@ -100,7 +100,7 @@
    </property>
    <property name="text">
     <string>Copyright (c) 2004 - 2016
-Image Processing Lab
+NeuroImaging and Surgical Technologies Lab
 McConnell Brain Imaging Centre
 Montréal Neurological Institute, McGill University</string>
    </property>

--- a/IbisLib/gui/pointerobjectsettingsdialog.cpp
+++ b/IbisLib/gui/pointerobjectsettingsdialog.cpp
@@ -165,16 +165,16 @@ void PointerObjectSettingsDialog::on_calibrationMatrixPushButton_toggled( bool o
 {
     if( on )
     {
-        Q_ASSERT_X( m_pointer, "TransformEditWidget::on_calibrationMatrixPushButton_toggled", "Can't call this function without setting PointerObject." );
+        Q_ASSERT_X( m_pointer, "PointerObjectSettingsDialog::on_calibrationMatrixPushButton_toggled", "Can't call this function without setting PointerObject." );
         Q_ASSERT( !m_matrixDialog );
 
         QString dialogTitle = m_pointer->GetName();
         dialogTitle += ": Pointer Calibration Matrix";
 
-        m_matrixDialog = new vtkQtMatrixDialog( true, 0 );
+        m_matrixDialog = new vtkQtMatrixDialog( false, 0 );
         m_matrixDialog->setWindowTitle( dialogTitle );
         m_matrixDialog->setAttribute( Qt::WA_DeleteOnClose );
-        m_matrixDialog->SetTransform( m_pointer->GetCalibrationTransform() );
+        m_matrixDialog->SetMatrix( m_pointer->GetCalibrationTransform()->GetMatrix() );
         m_matrixDialog->show();
         connect( m_matrixDialog, SIGNAL(destroyed()), this, SLOT(OnCalibrationMatrixDialogClosed()) );
     }

--- a/IbisLib/gui/trackerstatusdialog.cpp
+++ b/IbisLib/gui/trackerstatusdialog.cpp
@@ -99,14 +99,15 @@ void ToolUI::UpdateUI()
 
 void ToolUI::SnapshotButtonClicked()
 {
+    TrackedSceneObject * toolObject = TrackedSceneObject::SafeDownCast( m_manager->GetObjectByID( m_toolObjectId ) );
+    Q_ASSERT( toolObject );
+
     if( !this->SnapshotMatrixWidget )
     {
-        this->SnapshotMatrixWidget = new vtkQtMatrixDialog( false );
+        this->SnapshotMatrixWidget = new vtkQtMatrixDialog( true );
         connect( this->SnapshotMatrixWidget, SIGNAL(destroyed()), this, SLOT(SnapshotMatrixWidgetClosed()) );
     }
 
-    TrackedSceneObject * toolObject = TrackedSceneObject::SafeDownCast( m_manager->GetObjectByID( m_toolObjectId ) );
-    Q_ASSERT( toolObject );
 
     vtkMatrix4x4 * mat = vtkMatrix4x4::New();
     mat->DeepCopy( toolObject->GetWorldTransform()->GetMatrix() );

--- a/IbisLib/gui/trackerstatusdialog.h
+++ b/IbisLib/gui/trackerstatusdialog.h
@@ -25,6 +25,8 @@ public:
     ~ToolUI();
     
     void SetSceneManager( SceneManager * man, int m_toolObjectId );
+
+public slots:
     void UpdateUI();
 
 protected slots:

--- a/IbisLib/gui/transformeditwidget.cpp
+++ b/IbisLib/gui/transformeditwidget.cpp
@@ -157,8 +157,10 @@ void TransformEditWidget::EditMatrixButtonToggled( bool isOn )
             m_matrixDialog = new vtkQtMatrixDialog( readOnly, 0 );
             m_matrixDialog->setWindowTitle( dialogTitle );
             m_matrixDialog->setAttribute( Qt::WA_DeleteOnClose );
-            m_matrixDialog->SetTransform( t );
+            m_matrixDialog->SetMatrix( t->GetMatrix() );
             m_matrixDialog->show();
+            connect( m_matrixDialog, SIGNAL(Modified()), m_sceneObject, SLOT(NotifyTransformChanged()) );
+            connect( m_matrixDialog, SIGNAL(Modified()), this, SLOT(UpdateUi()) );
             connect( m_matrixDialog, SIGNAL(destroyed()), this, SLOT(EditMatrixDialogClosed()) );
         }
     }
@@ -190,7 +192,7 @@ void TransformEditWidget::WorldMatrixButtonToggled( bool isOn )
         m_worldMatrixDialog = new vtkQtMatrixDialog( true, 0 );
         m_worldMatrixDialog->setWindowTitle( dialogTitle );
         m_worldMatrixDialog->setAttribute( Qt::WA_DeleteOnClose );
-        m_worldMatrixDialog->SetTransform( m_sceneObject->GetWorldTransform() );
+        m_worldMatrixDialog->SetMatrix( m_sceneObject->GetWorldTransform()->GetMatrix() );
         m_worldMatrixDialog->show();
         connect( m_worldMatrixDialog, SIGNAL(destroyed()), this, SLOT(WorldMatrixDialogClosed()) );
     }

--- a/IbisLib/gui/usacquisitionsettingswidget.cpp
+++ b/IbisLib/gui/usacquisitionsettingswidget.cpp
@@ -200,9 +200,9 @@ void UsAcquisitionSettingsWidget::on_calibrationMatrixButton_toggled( bool check
     if( checked )
     {
         Q_ASSERT( !m_calibrationMatrixWidget );
-        m_calibrationMatrixWidget = new vtkQtMatrixDialog( false, 0 );
+        m_calibrationMatrixWidget = new vtkQtMatrixDialog( true, 0 );
         m_calibrationMatrixWidget->setAttribute( Qt::WA_DeleteOnClose );
-        m_calibrationMatrixWidget->SetTransform( m_acquisitionObject->GetCalibrationTransform() );
+        m_calibrationMatrixWidget->SetMatrix( m_acquisitionObject->GetCalibrationTransform()->GetMatrix() );
         m_calibrationMatrixWidget->setWindowTitle( m_acquisitionObject->GetName() + QString(" Calibration Matrix") );
         connect( m_calibrationMatrixWidget, SIGNAL(destroyed()), this, SLOT(OnCalibrationMatrixWidgetClosed()) );
         m_calibrationMatrixWidget->show();

--- a/IbisLib/gui/usprobeobjectsettingswidget.cpp
+++ b/IbisLib/gui/usprobeobjectsettingswidget.cpp
@@ -197,10 +197,10 @@ void UsProbeObjectSettingsWidget::on_calibrationMatrixPushButton_toggled( bool o
         QString dialogTitle = m_usProbeObject->GetName();
         dialogTitle += ": US Probe Calibration Matrix";
 
-        m_matrixDialog = new vtkQtMatrixDialog( true, 0 );
+        m_matrixDialog = new vtkQtMatrixDialog( false, 0 );
         m_matrixDialog->setWindowTitle( dialogTitle );
         m_matrixDialog->setAttribute( Qt::WA_DeleteOnClose );
-        m_matrixDialog->SetTransform( m_usProbeObject->GetCalibrationTransform() );
+        m_matrixDialog->SetMatrix( m_usProbeObject->GetCalibrationTransform()->GetMatrix() );
         m_matrixDialog->show();
         connect( m_matrixDialog, SIGNAL(destroyed()), this, SLOT(OnCalibrationMatrixDialogClosed()) );
     }

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
@@ -118,23 +118,14 @@ vtkQtMatrixDialog::vtkQtMatrixDialog( bool readOnly, QWidget* parent )
     m_revertButton->setEnabled(!readOnly);
     m_revertButton->setAutoDefault( false );
     Layout3->addWidget( m_revertButton );
-    
-    QSpacerItem* spacer_2 = new QSpacerItem( 20, 20, QSizePolicy::Expanding, QSizePolicy::Minimum );
-    Layout3->addItem( spacer_2 );
-    
-    MatrixDialogLayout->addLayout( Layout3 );
-    
-    Layout4 = new QHBoxLayout;
-    Layout4->setSpacing( 6 );
-    Layout4->setMargin( 0 );
-
+        
     m_copyButton = new QPushButton( this );
     m_copyButton->setObjectName("m_copyButton");
     m_copyButton->setText( tr( "Copy" ) );
     m_copyButton->setMinimumSize( QSize( 70, 30 ) );
     m_copyButton->setMaximumSize( QSize( 70, 30 ) );
     m_copyButton->setAutoDefault( false );
-    Layout4->addWidget( m_copyButton );
+    Layout3->addWidget( m_copyButton );
 
     m_pasteButton = new QPushButton( this );
     m_pasteButton->setObjectName("m_pasteButton");
@@ -143,12 +134,10 @@ vtkQtMatrixDialog::vtkQtMatrixDialog( bool readOnly, QWidget* parent )
     m_pasteButton->setMaximumSize( QSize( 70, 30 ) );
     m_pasteButton->setEnabled(!readOnly);
     m_pasteButton->setAutoDefault( false );
-    Layout4->addWidget( m_pasteButton );
+    Layout3->addWidget( m_pasteButton );
 
-    QSpacerItem* spacer_3 = new QSpacerItem( 20, 20, QSizePolicy::Expanding, QSizePolicy::Minimum );
-    Layout4->addItem( spacer_3 );
 
-    MatrixDialogLayout->addLayout( Layout4 );
+    MatrixDialogLayout->addLayout( Layout3);
 
     // signals and slots connections
     connect( m_invertButton, SIGNAL( clicked() ), this, SLOT( InvertButtonClicked() ) );

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
@@ -21,11 +21,12 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <qfile.h>
 #include <qfiledialog.h>
 #include <qstring.h>
-#include <qmessagebox.h>
+#include <QApplication>
+#include <QMimeData>
+#include <QClipboard>
+#include <QMessageBox>
 #include "vtkObject.h"
 #include "vtkMatrix4x4.h"
-#include "vtkHomogeneousTransform.h"
-#include "vtkTransform.h"
 #include "vtkXFMReader.h"
 #include "vtkXFMWriter.h"
 #include "vtkEventQtSlotConnect.h"
@@ -33,7 +34,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 vtkQtMatrixDialog::vtkQtMatrixDialog( bool readOnly, QWidget* parent )
     : QDialog( parent, Qt::WindowStaysOnTopHint )
     , m_readOnly( readOnly )
-    , m_transform( 0 )
     , m_matrix( 0 )
 {
     resize( 511, 210 );
@@ -60,6 +60,7 @@ vtkQtMatrixDialog::vtkQtMatrixDialog( bool readOnly, QWidget* parent )
             m_matEdit[i][j]->setReadOnly( readOnly );
             m_matEdit[i][j]->setAlignment( Qt::AlignRight );
             m_matEdit[i][j]->setMaxLength( 12 );
+            connect( m_matEdit[i][j], SIGNAL(returnPressed()), this, SLOT(LineEditChanged()) );
             gridBox->addWidget( m_matEdit[i][j], i, j );
         }
     }
@@ -80,6 +81,7 @@ vtkQtMatrixDialog::vtkQtMatrixDialog( bool readOnly, QWidget* parent )
     m_identityButton->setMinimumSize( QSize( 70, 30 ) );
     m_identityButton->setMaximumSize( QSize( 70, 30 ) );
     m_identityButton->setEnabled(!readOnly);
+    m_identityButton->setAutoDefault( false );
     Layout3->addWidget( m_identityButton );
     
     m_invertButton = new QPushButton( this );
@@ -88,6 +90,7 @@ vtkQtMatrixDialog::vtkQtMatrixDialog( bool readOnly, QWidget* parent )
     m_invertButton->setMinimumSize( QSize( 70, 30 ) );
     m_invertButton->setMaximumSize( QSize( 70, 30 ) );
     m_invertButton->setEnabled(!readOnly);
+    m_invertButton->setAutoDefault( false );
     Layout3->addWidget( m_invertButton );
     
     m_loadButton = new QPushButton( this );
@@ -96,13 +99,15 @@ vtkQtMatrixDialog::vtkQtMatrixDialog( bool readOnly, QWidget* parent )
     m_loadButton->setMinimumSize( QSize( 70, 30 ) );
     m_loadButton->setMaximumSize( QSize( 70, 30 ) );
     m_loadButton->setEnabled(!readOnly);
+    m_loadButton->setAutoDefault( false );
     Layout3->addWidget( m_loadButton );
     
     m_saveButton = new QPushButton( this );
-	m_saveButton->setObjectName("m_loadButton");
+    m_saveButton->setObjectName("m_saveButton");
     m_saveButton->setText( tr( "Save" ) );
     m_saveButton->setMinimumSize( QSize( 70, 30 ) );
     m_saveButton->setMaximumSize( QSize( 70, 30 ) );
+    m_saveButton->setAutoDefault( false );
     Layout3->addWidget( m_saveButton );
     
     m_revertButton = new QPushButton( this );
@@ -111,28 +116,48 @@ vtkQtMatrixDialog::vtkQtMatrixDialog( bool readOnly, QWidget* parent )
     m_revertButton->setMinimumSize( QSize( 70, 30 ) );
     m_revertButton->setMaximumSize( QSize( 70, 30 ) );
     m_revertButton->setEnabled(!readOnly);
+    m_revertButton->setAutoDefault( false );
     Layout3->addWidget( m_revertButton );
     
     QSpacerItem* spacer_2 = new QSpacerItem( 20, 20, QSizePolicy::Expanding, QSizePolicy::Minimum );
     Layout3->addItem( spacer_2 );
-
-    m_applyButton = new QPushButton( this );
-    m_applyButton->setObjectName("m_applyButton");
-    m_applyButton->setText( tr( "Apply" ) );
-    m_applyButton->setMinimumSize( QSize( 70, 30 ) );
-    m_applyButton->setMaximumSize( QSize( 70, 30 ) );
-    m_applyButton->setEnabled(!readOnly);
-    Layout3->addWidget( m_applyButton );
     
     MatrixDialogLayout->addLayout( Layout3 );
     
+    Layout4 = new QHBoxLayout;
+    Layout4->setSpacing( 6 );
+    Layout4->setMargin( 0 );
+
+    m_copyButton = new QPushButton( this );
+    m_copyButton->setObjectName("m_copyButton");
+    m_copyButton->setText( tr( "Copy" ) );
+    m_copyButton->setMinimumSize( QSize( 70, 30 ) );
+    m_copyButton->setMaximumSize( QSize( 70, 30 ) );
+    m_copyButton->setAutoDefault( false );
+    Layout4->addWidget( m_copyButton );
+
+    m_pasteButton = new QPushButton( this );
+    m_pasteButton->setObjectName("m_pasteButton");
+    m_pasteButton->setText( tr( "Paste" ) );
+    m_pasteButton->setMinimumSize( QSize( 70, 30 ) );
+    m_pasteButton->setMaximumSize( QSize( 70, 30 ) );
+    m_pasteButton->setEnabled(!readOnly);
+    m_pasteButton->setAutoDefault( false );
+    Layout4->addWidget( m_pasteButton );
+
+    QSpacerItem* spacer_3 = new QSpacerItem( 20, 20, QSizePolicy::Expanding, QSizePolicy::Minimum );
+    Layout4->addItem( spacer_3 );
+
+    MatrixDialogLayout->addLayout( Layout4 );
+
     // signals and slots connections
     connect( m_invertButton, SIGNAL( clicked() ), this, SLOT( InvertButtonClicked() ) );
     connect( m_identityButton, SIGNAL( clicked() ), this, SLOT( IdentityButtonClicked() ) );
     connect( m_revertButton, SIGNAL( clicked() ), this, SLOT( RevertButtonClicked() ) );
-    connect( m_applyButton, SIGNAL( clicked() ), this, SLOT( ApplyButtonClicked() ) );
     connect( m_loadButton, SIGNAL( clicked() ), this, SLOT( LoadButtonClicked() ) );
     connect( m_saveButton, SIGNAL( clicked() ), this, SLOT( SaveButtonClicked() ) );
+    connect( m_copyButton, SIGNAL( clicked() ), this, SLOT( CopyButtonClicked() ) );
+    connect( m_pasteButton, SIGNAL( clicked() ), this, SLOT( PasteButtonClicked() ) );
     UpdateUI();
     m_directory = QDir::homePath();
 }
@@ -143,53 +168,41 @@ vtkQtMatrixDialog::~vtkQtMatrixDialog()
 
     if( m_matrix )
         m_matrix->UnRegister( 0 );
-    if( m_transform )
-        m_transform->UnRegister( 0 );
 
     m_copy_matrix->Delete();
 }
 
 void vtkQtMatrixDialog::SetMatrixElements( )
 {
-    vtkMatrix4x4 * mat = 0;
-    if( m_transform )
-        mat = m_transform->GetMatrix();
-    else
-        mat = m_matrix;
-
-    if( mat )
+    for( int i = 0; i < 4; i++ )
     {
-        for( int i = 0; i < 4; i++ )
+        for( int j = 0; j < 4; j++ )
         {
-            for( int j = 0; j < 4; j++ )
-            {
-                mat->SetElement( i, j, m_matEdit[i][j]->text().toDouble() );
-            }
+            m_matrix->SetElement( i, j, m_matEdit[i][j]->text().toDouble() );
         }
     }
-
-    if( m_transform )
-        m_transform->Modified();
+    m_matrix->Modified();
+    emit Modified();
 }
 
 void vtkQtMatrixDialog::InvertButtonClicked()
 {
     if( m_matrix )
+    {
+        m_copy_matrix->DeepCopy( m_matrix );
         m_matrix->Invert();
-    if( m_transform )
-        m_transform->Inverse();
+        emit Modified();
+    }
 }
 
 
 void vtkQtMatrixDialog::IdentityButtonClicked()
 {
     if( m_matrix )
-        m_matrix->Identity();
-    if( m_transform )
     {
-        vtkTransform * t = vtkTransform::SafeDownCast( m_transform );
-        Q_ASSERT_X( t, "vtkQtMatrixDialog::IdentityButtonClicked()", "Can't edit a transform that is not a vtkTransform." );
-        t->Identity();
+        m_copy_matrix->DeepCopy( m_matrix );
+        m_matrix->Identity();
+        emit Modified();
     }
 }
 
@@ -197,13 +210,12 @@ void vtkQtMatrixDialog::IdentityButtonClicked()
 void vtkQtMatrixDialog::RevertButtonClicked()
 {
     if( m_matrix )
-        m_matrix->DeepCopy( m_copy_matrix );
-    if( m_transform )
     {
-        vtkTransform * t = vtkTransform::SafeDownCast( m_transform );
-        Q_ASSERT_X( t, "vtkQtMatrixDialog::RevertButtonClicked()", "Can't edit a transform that is not a vtkTransform." );
-        t->SetMatrix( m_copy_matrix );
+        m_matrix->DeepCopy( m_copy_matrix );
+        m_copy_matrix->Identity();
+        emit Modified();
     }
+    UpdateUI();
 }
 
 
@@ -215,8 +227,6 @@ void vtkQtMatrixDialog::MatrixChanged()
 
 void vtkQtMatrixDialog::SetMatrix( vtkMatrix4x4 * mat )
 {
-    Q_ASSERT_X( !m_transform, "vtkQtMatrixDialog::SetMatrix", "Can't set both matrix and transform." );
-
     if( m_matrix )
     {
         m_eventSlotConnect->Disconnect( m_matrix );
@@ -226,56 +236,22 @@ void vtkQtMatrixDialog::SetMatrix( vtkMatrix4x4 * mat )
     m_matrix = mat;
     if( m_matrix )
     {
-        m_copy_matrix->DeepCopy( m_matrix );
+        m_copy_matrix->Identity();
         m_matrix->Register( NULL );
         m_eventSlotConnect->Connect( m_matrix, vtkCommand::ModifiedEvent, this, SLOT(MatrixChanged()), 0, 0.0, Qt::QueuedConnection );
-    }
-    UpdateUI();   
-}
-
-void vtkQtMatrixDialog::SetTransform( vtkHomogeneousTransform * t )
-{
-    Q_ASSERT_X( !m_matrix, "vtkQtMatrixDialog::SetTransform", "Can't set both matrix and transform." );
-    Q_ASSERT_X( m_readOnly || vtkTransform::SafeDownCast( t ), "vtkQtMatrixDialog::SetTransform()", "Transform has to be a vtkTransform or dialog read-only" );
-
-    if( m_transform )
-    {
-        m_eventSlotConnect->Disconnect( m_transform );
-        m_transform->UnRegister( NULL );
-    }
-
-    m_transform = t;
-    if( m_transform )
-    {
-        m_copy_matrix->DeepCopy( m_transform->GetMatrix() );
-        m_transform->Register( NULL );
-        m_eventSlotConnect->Connect( m_transform, vtkCommand::ModifiedEvent, this, SLOT(MatrixChanged()), 0, 0.0, Qt::QueuedConnection );
     }
     UpdateUI();
 }
 
-vtkMatrix4x4 * vtkQtMatrixDialog::GetMatrix( )
-{
-    if( m_transform )
-        return m_transform->GetMatrix();
-    return m_matrix;
-}
-
 void vtkQtMatrixDialog::UpdateUI()
 {
-    vtkMatrix4x4 * mat = 0;
-    if( m_transform )
-        mat = m_transform->GetMatrix();
-    else
-        mat = m_matrix;
-
-    if( mat )
+    if( m_matrix )
     {
         for( int i = 0; i < 4; i++ )
         {
             for( int j = 0; j < 4; j++ )
             {
-                m_matEdit[i][j]->setText( QString::number( mat->Element[i][j], 'g', 15 ) );
+                m_matEdit[i][j]->setText( QString::number( m_matrix->Element[i][j], 'g', 15 ) );
             }
         }
     }
@@ -291,84 +267,50 @@ void vtkQtMatrixDialog::UpdateUI()
     }
 }
 
-void vtkQtMatrixDialog::ApplyButtonClicked()
-{
-    SetMatrixElements( );
-}
-
 void vtkQtMatrixDialog::LoadButtonClicked()
 {
     // Get filename from user
-    if( !QFile::exists( m_directory ) )
-    {
-        m_directory = QDir::homePath();
-    }
 
     QString filename = QFileDialog::getOpenFileName( this, tr("Open XFM file"), m_directory, tr("*.xfm") );
     if( !filename.isEmpty() )
     {
         QFile OpenFile( filename );
         vtkMatrix4x4 * mat = vtkMatrix4x4::New();
-        bool valid = false;
-
-        int type = GetFileType(&OpenFile);
-        if (type == TEXT_FILE)
+        vtkXFMReader *reader = vtkXFMReader::New();
+        if( reader->CanReadFile( filename.toUtf8() ) )
         {
-            valid = LoadFromTextFile( &OpenFile, mat );
-        }
-        else if (type == XFM_FILE)
-        {
-            valid = LoadFromXFMFile( &OpenFile, mat); // I'm not checking the return because it would be redundant. GetType()  would fail first.
+            reader->SetFileName(filename.toUtf8() );
+            reader->SetMatrix(mat);
+            reader->Update();
+            reader->Delete();
+            if( m_matrix )
+                m_matrix->DeepCopy( mat );
+            mat->Delete();
+            UpdateUI();
+            emit Modified();
         }
         else
         {
-            QMessageBox::warning( this, "Error: ", "Unknown file format.", 1, 0 );
-        }
-
-        if( valid )
-        {
-            if( m_matrix )
-                m_matrix->DeepCopy( mat );
-            if( m_transform )
-            {
-                vtkTransform * t = vtkTransform::SafeDownCast( m_transform );
-                Q_ASSERT_X( t, "vtkQtMatrixDialog::LoadButtonClicked()", "Can't edit a transform that is not a vtkTransform." );
-                t->SetMatrix( mat );
-            }
+            reader->Delete();
+            mat->Delete();
+            return;
         }
 
         QFileInfo info( OpenFile.fileName() );
         m_directory = info.absolutePath();
-
-        mat->Delete();
     }
  }
 
 void vtkQtMatrixDialog::SaveButtonClicked()
 {
-    vtkMatrix4x4 * mat = 0;
-    if( m_transform )
-        mat = m_transform->GetMatrix();
-    else
-        mat = m_matrix;
-
-    if( !mat )
-    {
-        std::cerr << "Trying to save matrix that is null";
-        return;
-    }
-
-    if( !QFile::exists( m_directory ) )
-    {
-        m_directory = QDir::homePath();
-    }
+    Q_ASSERT( m_matrix );
 
     QString filename = QFileDialog::getSaveFileName( this, tr("Save XFM file"), m_directory, tr("*.xfm") );
     if( !filename.isEmpty() )
     {
         vtkXFMWriter * writer = vtkXFMWriter::New();
         writer->SetFileName( filename.toUtf8().data() );
-        writer->SetMatrix( mat );
+        writer->SetMatrix( m_matrix );
         writer->Write();
         writer->Delete();
         QFileInfo info( filename );
@@ -376,72 +318,53 @@ void vtkQtMatrixDialog::SaveButtonClicked()
     }
 }
 
-int vtkQtMatrixDialog::GetFileType(QFile *f)
+void vtkQtMatrixDialog::CopyButtonClicked()
 {
-    char line[256];
-    if (!f->open(QIODevice::ReadOnly))
+    QClipboard *clipboard = QApplication::clipboard();
+    QString all_matrix_elements;
+    for( int i = 0; i < 4; i++ )
     {
-        QMessageBox::warning( this, "Read error: can't open file" , f->fileName(), 1, 0 );
-        return UNKNOWN_FILE_TYPE;
-    }
-    line[0] = 0;
-    f->readLine( line, 256 );
-    f->close();
-    if ( isdigit(line[0]) || (line[0] == '-') )
-        return TEXT_FILE;
-    else
-    {
-        if( strncmp( line, "MNI Transform File", 18 ) == 0 )
-            return XFM_FILE;
-    }
-    return UNKNOWN_FILE_TYPE;
-}
-
-bool vtkQtMatrixDialog::LoadFromXFMFile( QFile *f, vtkMatrix4x4 * mat )
-{
-    vtkXFMReader *reader = vtkXFMReader::New();
-    if( reader->CanReadFile( f->fileName().toUtf8() ) )
-    {    
-        reader->SetFileName(f->fileName().toUtf8() );
-        reader->SetMatrix(mat);
-        reader->Update();
-        reader->Delete();    
-        return true;
-    }
-    reader->Delete();    
-    return false;
-}
-
-bool vtkQtMatrixDialog::LoadFromTextFile(QFile *f, vtkMatrix4x4 * mat )
-{
-    char line[256], *tok;
-    int ok = 1;
-    if (!f->open(QIODevice::ReadOnly))
-    {
-        QMessageBox::warning( this, "Read error: can't open file" , f->fileName(), 1, 0 );
-        return false;
-    }
-    line[0] = 0;
-    f->readLine( line, 256 );
-    f->close();
-    
-
-    tok = strtok( line, " \t" );
-    for( int i = 0; i < 4 && ok; i++ )
-    {
-        for( int j = 0; j < 4 && ok; j++ )
+        for( int j = 0; j < 4; j++ )
         {
-            if ( tok )
-            {
-                mat->SetElement( i, j, atof(tok) );
-                tok = strtok( NULL, " \t" );
-            }
-            else
-                ok = 0;
+            all_matrix_elements.append( m_matEdit[i][j]->text() );
+            all_matrix_elements.append(' ');
         }
     }
+    all_matrix_elements.remove( all_matrix_elements.size()-1, 1);
+    clipboard->setText( all_matrix_elements );
+}
 
-    return true;
+void vtkQtMatrixDialog::PasteButtonClicked()
+{
+    QClipboard *clipboard = QApplication::clipboard();
+    const QMimeData *mimeData = clipboard->mimeData();
+
+    m_copy_matrix->DeepCopy( m_matrix );
+    if (mimeData->hasText())
+    {
+        QString text(mimeData->text());
+        QStringList list = mimeData->text().split( ' ' );
+        if( list.size() == 16 )
+        {
+            int l = 0;
+            for( int i = 0; i < 4; i++ )
+            {
+                for( int j = 0; j < 4; j++ )
+                {
+                    m_matEdit[i][j]->setText( list.at( l++ ) );
+                }
+            }
+            this->SetMatrixElements();
+        }
+        else
+        {
+            QMessageBox::warning( 0, "Warning", "Clipboard does not contain matrix elements." );
+        }
+    }
+    else
+    {
+        QMessageBox::warning( 0, "Warning", "Nothing saved in clipboard." );
+    }
 }
 
 void vtkQtMatrixDialog::SetDirectory(const QString &dir)
@@ -451,4 +374,10 @@ void vtkQtMatrixDialog::SetDirectory(const QString &dir)
     {
         m_directory = QDir::homePath();
     }
+}
+
+void vtkQtMatrixDialog::LineEditChanged()
+{
+    m_copy_matrix->DeepCopy( m_matrix );
+    this->SetMatrixElements();
 }

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.h
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.h
@@ -26,8 +26,6 @@ class vtkMatrix4x4;
 class vtkHomogeneousTransform;
 class vtkEventQtSlotConnect;
 
-enum FILETYPE {UNKNOWN_FILE_TYPE, TEXT_FILE, XFM_FILE, XML_FILE};
-
 class vtkQtMatrixDialog : public QDialog
 { 
     Q_OBJECT
@@ -38,8 +36,6 @@ public:
     ~vtkQtMatrixDialog();
 
     void SetMatrix( vtkMatrix4x4 * mat );
-    void SetTransform( vtkHomogeneousTransform * t );
-    vtkMatrix4x4 * GetMatrix( );
     void SetDirectory(const QString &dir);
     void UpdateUI();
 
@@ -47,24 +43,31 @@ public:
     QPushButton * m_invertButton;
     QPushButton * m_identityButton;
     QPushButton * m_revertButton;
-    QPushButton * m_applyButton;
     QPushButton * m_loadButton;
     QPushButton * m_saveButton;
-        
+    QPushButton * m_copyButton;
+    QPushButton * m_pasteButton;
+
+signals:
+
+    void Modified();
+
 public slots:
     
     void InvertButtonClicked();
     void IdentityButtonClicked();
     void RevertButtonClicked();
     void MatrixChanged();
-    void ApplyButtonClicked();
     void LoadButtonClicked();
     void SaveButtonClicked();
+    void CopyButtonClicked();
+    void PasteButtonClicked();
+    void SetMatrixElements( );
+    void LineEditChanged();
 
 protected:
 
     bool m_readOnly;
-    vtkHomogeneousTransform * m_transform;
     vtkMatrix4x4 * m_matrix;
     vtkMatrix4x4 * m_copy_matrix;
     QString m_directory;
@@ -74,11 +77,9 @@ protected:
     QVBoxLayout * MatrixDialogLayout;
     QGridLayout * gridBox;
     QHBoxLayout * Layout3;
+    QHBoxLayout * Layout4;
 
-    void  SetMatrixElements( );
-    int   GetFileType(QFile *f); 
     bool  LoadFromXFMFile(QFile *f, vtkMatrix4x4 * mat);
-    bool  LoadFromTextFile(QFile *f, vtkMatrix4x4 * mat);
 };
 
 

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.h
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.h
@@ -77,7 +77,6 @@ protected:
     QVBoxLayout * MatrixDialogLayout;
     QGridLayout * gridBox;
     QHBoxLayout * Layout3;
-    QHBoxLayout * Layout4;
 
     bool  LoadFromXFMFile(QFile *f, vtkMatrix4x4 * mat);
 };


### PR DESCRIPTION
Changes to the matrix elemnts are now instantly applied and Apply button is removed.
Copy and paste are using clipboard.  User is alolowed to modify calibration matrices of PointerObject and USProbeObject using vtkQtMatrixDialog.  
Some obsolete headers were removed.