### PR TITLE
Modified deleting ImageObject

### DIFF
--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -642,9 +642,6 @@ void SceneManager::RemoveObject( SceneObject * object , bool viewChange)
 
     object->ObjectAboutToBeRemovedFromScene();
 
-    // remove the object from the global list
-    this->AllObjects.removeAt( indexAll );
-
     // remove all children
     this->RemoveAllChildrenObjects(object);
 
@@ -664,6 +661,24 @@ void SceneManager::RemoveObject( SceneObject * object , bool viewChange)
     if( object->IsListable() )
         emit StartRemovingObject( object->GetParent(), position );
 
+    // Set ReferenceDataObject if needed
+    if (object == this->ReferenceDataObject)
+    {
+        this->ReferenceDataObject  = 0;
+        QList< ImageObject* > imObjects;
+        this->GetAllImageObjects( imObjects );
+        int i = 0;
+        bool refSet = false;
+        while (i < imObjects.size() && !refSet )
+        {
+            if( imObjects[i] != object )
+            {
+                this->SetReferenceDataObject( imObjects[i] );
+                refSet = true;
+            }
+            i++;
+        }
+    }
 
     // Release from all views
     for( ViewList::iterator it = Views.begin(); it != Views.end(); ++it )
@@ -682,11 +697,13 @@ void SceneManager::RemoveObject( SceneObject * object , bool viewChange)
 
     object->UnRegister( this );
 
-    if (object == this->ReferenceDataObject)
-        this->ReferenceDataObject  = 0;
     if( object->IsListable() )
         emit FinishRemovingObject();
     ValidatePointerObject();
+
+    // remove the object from the global list
+    this->AllObjects.removeAt( indexAll );
+
     emit ObjectRemoved( objId );
 }
 

--- a/IbisLib/triplecutplaneobject.cpp
+++ b/IbisLib/triplecutplaneobject.cpp
@@ -240,6 +240,7 @@ void TripleCutPlaneObject::RemoveImage( int imageID )
         if ((*it) == imageID)
         {
             m_sliceMixMode.erase(m_sliceMixMode.begin()+i);
+            m_blendingModeIndices.erase(m_blendingModeIndices.begin()+i);
             ImageObject * im = ImageObject::SafeDownCast( this->GetManager()->GetObjectByID( imageID ) );
             if(im )
             {
@@ -253,12 +254,7 @@ void TripleCutPlaneObject::RemoveImage( int imageID )
             return;
 
     Images.erase( it );
-    if( this->GetManager()->GetReferenceDataObject()->GetObjectID() == imageID && Images.size() != 0 )
-    {
-        this->GetManager()->SetReferenceDataObject( this->GetManager()->GetObjectByID( Images[0] )); // emits callback that will execute AdjustAllImages()
-    }
-    else
-        this->AdjustAllImages();
+    this->AdjustAllImages();
 
     if( Images.size() == 0 )
         ReleaseAllViews();
@@ -266,15 +262,17 @@ void TripleCutPlaneObject::RemoveImage( int imageID )
 
 void TripleCutPlaneObject::AdjustAllImages()
 {
+    for( int j = 0; j < 3; ++j )
+    {
+        // remove all inputs and later re-add images.
+        this->Planes[j]->ClearAllInputs();
+    }
     ImageObject *referenceObject = this->GetManager()->GetReferenceDataObject();
     if( referenceObject && Images.size() > 0 )
     {
         int refID = referenceObject->GetObjectID();
         for( int j = 0; j < 3; ++j )
         {
-            // remove all inputs and re-add images.
-            // (seems stupid, but it is better like that for texture unit consistency)
-            this->Planes[j]->ClearAllInputs();
             // first add reference object
             bool canInterpolate = !referenceObject->IsLabelImage();
             this->Planes[j]->SetBoundingVolume( referenceObject->GetImage(), referenceObject->GetWorldTransform() );


### PR DESCRIPTION
When removing ReferenceDataObject the new one is set in SceneManager::RemoveObject(). 
In TripleCutPlane the textures of removed image must also be removed.