### PR TITLE
Static camera hotfix

### DIFF
--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -828,7 +828,7 @@ void SceneManager::GetAllTrackedObjects( QList<TrackedSceneObject*> & all )
     for( int i = 0; i < this->AllObjects.size(); ++i )
     {
         TrackedSceneObject * obj = TrackedSceneObject::SafeDownCast( this->AllObjects[i] );
-        if( obj )
+        if( obj && obj->IsDrivenByHardware() )
             all.push_back( obj );
     }
 }


### PR DESCRIPTION
Fixed a problem that caused static cameras to be treated as tracker tools.