### PR TITLE
Normalized coordinate AR transparency

### DIFF
--- a/IbisLib/cameraobject.cpp
+++ b/IbisLib/cameraobject.cpp
@@ -334,8 +334,8 @@ void CameraObject::Setup( View * view )
         perView.cameraImageMapper->SetUseTransparency( m_useTransparency );
         perView.cameraImageMapper->SetUseGradient( m_useGradient );
         perView.cameraImageMapper->SetShowMask( m_showMask );
-        perView.cameraImageMapper->SetTransparencyPosition( m_transparencyCenter[0] * GetImageWidth(), m_transparencyCenter[1] * GetImageHeight() );
-        perView.cameraImageMapper->SetTransparencyRadius( m_transparencyRadius[0] * GetImageWidth(), m_transparencyRadius[1] * GetImageWidth() );
+        perView.cameraImageMapper->SetTransparencyPosition( m_transparencyCenter[0], m_transparencyCenter[1] );
+        perView.cameraImageMapper->SetTransparencyRadius( m_transparencyRadius[0], m_transparencyRadius[1] );
         perView.cameraImageActor->SetMapper( perView.cameraImageMapper );
         perView.cameraImageMapper->SetInputConnection( m_videoInputSwitch->GetOutputPort() );
         view->GetRenderer()->AddViewProp( perView.cameraImageActor );
@@ -474,7 +474,7 @@ void CameraObject::GetImageCenterPix( double & x, double & y )
 void CameraObject::GetFocalPix( double & x, double & y )
 {
     x = m_intrinsicParams.m_focal[0] * GetImageWidth();
-    x = m_intrinsicParams.m_focal[1] * GetImageHeight();
+    y = m_intrinsicParams.m_focal[1] * GetImageHeight();
 }
 
 void CameraObject::SetLensDistortion( double dist )
@@ -920,7 +920,7 @@ void CameraObject::VideoUpdatedSlot()
             WorldToImage( tip, cx, cy );
 
             // Set new center for transparency
-            SetTransparencyCenter( cx, cy );
+            SetTransparencyCenter( cx / GetImageWidth(), cy / GetImageHeight() );
         }
     }
 
@@ -966,8 +966,8 @@ void CameraObject::UpdateGeometricRepresentation()
         PerViewElements & elem = (*it).second;
         elem.cameraImageMapper->SetImageCenter( m_intrinsicParams.m_center[0] * GetImageWidth(), m_intrinsicParams.m_center[1] * GetImageHeight() );
         elem.cameraImageMapper->SetLensDistortion( m_intrinsicParams.m_distorsionK1 );
-        elem.cameraImageMapper->SetTransparencyPosition( m_transparencyCenter[0] * width, m_transparencyCenter[1] * height );
-        elem.cameraImageMapper->SetTransparencyRadius( m_transparencyRadius[0] * width, m_transparencyRadius[1] * width );
+        elem.cameraImageMapper->SetTransparencyPosition( m_transparencyCenter[0], m_transparencyCenter[1] );
+        elem.cameraImageMapper->SetTransparencyRadius( m_transparencyRadius[0], m_transparencyRadius[1] );
         ++it;
     }
     m_camera->SetViewAngle( m_intrinsicParams.GetVerticalAngleDegrees() );

--- a/IbisLib/gui/cameraobjectsettingswidget.cpp
+++ b/IbisLib/gui/cameraobjectsettingswidget.cpp
@@ -182,20 +182,20 @@ void CameraObjectSettingsWidget::UpdateUI()
 
     ui->xTransparencyCenterSlider->blockSignals( true );
     ui->xTransparencyCenterSlider->setEnabled( !m_camera->IsTransparencyCenterTracked() );
-    ui->xTransparencyCenterSlider->setValue( (int)(m_camera->GetTransparencyCenter()[0] / m_camera->GetImageWidth() * 100.0) );
+    ui->xTransparencyCenterSlider->setValue( (int)(m_camera->GetTransparencyCenter()[0] * 100.0) );
     ui->xTransparencyCenterSlider->blockSignals( false );
 
     ui->yTransparencyCenterSlider->blockSignals( true );
     ui->yTransparencyCenterSlider->setEnabled( !m_camera->IsTransparencyCenterTracked() );
-    ui->yTransparencyCenterSlider->setValue( (int)(m_camera->GetTransparencyCenter()[1] / m_camera->GetImageHeight() * 100.0) );
+    ui->yTransparencyCenterSlider->setValue( (int)(m_camera->GetTransparencyCenter()[1] * 100.0) );
     ui->yTransparencyCenterSlider->blockSignals( false );
 
     ui->minTransparencyRadiusSlider->blockSignals( true );
-    ui->minTransparencyRadiusSlider->setValue( (int)(m_camera->GetTransparencyRadius()[0] / 1000.0 * 100.0) );
+    ui->minTransparencyRadiusSlider->setValue( (int)(m_camera->GetTransparencyRadius()[0] * 100.0) );
     ui->minTransparencyRadiusSlider->blockSignals( false );
 
     ui->maxTransparencyRadiusSlider->blockSignals( true );
-    ui->maxTransparencyRadiusSlider->setValue( (int)(m_camera->GetTransparencyRadius()[1] / 1000.0 * 100.0) );
+    ui->maxTransparencyRadiusSlider->setValue( (int)(m_camera->GetTransparencyRadius()[1] * 100.0) );
     ui->maxTransparencyRadiusSlider->blockSignals( false );
 
 }
@@ -254,8 +254,8 @@ void CameraObjectSettingsWidget::CalibrationMatrixDialogClosed()
 void CameraObjectSettingsWidget::on_xTransparencyCenterSlider_valueChanged(int value)
 {
     Q_ASSERT( m_camera );
-    double realValue = (double)value * .01 * m_camera->GetImageWidth();
-    double yRealValue = (double)(ui->yTransparencyCenterSlider->value()) * .01 * m_camera->GetImageHeight();
+    double realValue = (double)value * .01;
+    double yRealValue = (double)(ui->yTransparencyCenterSlider->value()) * .01;
     m_camera->SetTransparencyCenter( realValue, yRealValue );
     UpdateUI();
 }
@@ -263,8 +263,8 @@ void CameraObjectSettingsWidget::on_xTransparencyCenterSlider_valueChanged(int v
 void CameraObjectSettingsWidget::on_yTransparencyCenterSlider_valueChanged(int value)
 {
     Q_ASSERT( m_camera );
-    double realValue = (double)value * .01 * m_camera->GetImageHeight();
-    double xRealValue = (double)(ui->xTransparencyCenterSlider->value()) * .01 * m_camera->GetImageWidth();
+    double realValue = (double)value * .01;
+    double xRealValue = (double)(ui->xTransparencyCenterSlider->value()) * .01;
     m_camera->SetTransparencyCenter( xRealValue, realValue );
     UpdateUI();
 }
@@ -272,8 +272,8 @@ void CameraObjectSettingsWidget::on_yTransparencyCenterSlider_valueChanged(int v
 void CameraObjectSettingsWidget::on_minTransparencyRadiusSlider_valueChanged(int value)
 {
     Q_ASSERT( m_camera );
-    double realValue = (double)value * .01 * 1000.0;
-    double maxRealValue = (double)(ui->maxTransparencyRadiusSlider->value()) * .01 * 1000.0;
+    double realValue = (double)value * .01;
+    double maxRealValue = (double)(ui->maxTransparencyRadiusSlider->value()) * .01;
     if( realValue > maxRealValue )
         realValue = maxRealValue;
     m_camera->SetTransparencyRadius( realValue, maxRealValue );
@@ -283,8 +283,8 @@ void CameraObjectSettingsWidget::on_minTransparencyRadiusSlider_valueChanged(int
 void CameraObjectSettingsWidget::on_maxTransparencyRadiusSlider_valueChanged(int value)
 {
     Q_ASSERT( m_camera );
-    double realValue = (double)value * .01 * 1000.0;
-    double minRealValue = (double)(ui->minTransparencyRadiusSlider->value()) * .01 * 1000.0;
+    double realValue = (double)value * .01;
+    double minRealValue = (double)(ui->minTransparencyRadiusSlider->value()) * .01;
     if( realValue < minRealValue )
         realValue = minRealValue;
     m_camera->SetTransparencyRadius( minRealValue, realValue );

--- a/IbisVTK/vtkExtensions/vtkIbisImagePlaneMapper.cxx
+++ b/IbisVTK/vtkExtensions/vtkIbisImagePlaneMapper.cxx
@@ -103,8 +103,12 @@ int vtkIbisImagePlaneMapper::RenderTranslucentPolygonalGeometry( vtkRenderer *re
     this->Shader->SetVariable( "UseTransparency", this->UseTransparency );
     this->Shader->SetVariable( "UseGradient", this->UseGradient );
     this->Shader->SetVariable( "ShowMask", this->ShowMask );
-    this->Shader->SetVariable( "TransparencyPosition", (float)this->TransparencyPosition[0], (float)this->TransparencyPosition[1] );
-    this->Shader->SetVariable( "TransparencyRadius", (float)this->TransparencyRadius[0], (float)this->TransparencyRadius[1] );
+    float transpPosX = (float)(this->TransparencyPosition[0] * dim[0]);
+    float transpPosY = (float)(this->TransparencyPosition[1] * dim[1]);
+    this->Shader->SetVariable( "TransparencyPosition", transpPosX, transpPosY );
+    float transpMin = (float)(this->TransparencyRadius[0] * dim[0]);
+    float transpMax = (float)(this->TransparencyRadius[1] * dim[0]);
+    this->Shader->SetVariable( "TransparencyRadius", transpMin, transpMax );
     this->Shader->SetVariable( "ImageOffset", (float)offsetX, (float)offsetY );
     this->Shader->SetVariable( "LensDistortion", (float)this->LensDistortion );
     this->Shader->SetVariable( "GlobalOpacity", (float)(this->GlobalOpacity) );


### PR DESCRIPTION
Fixed a bug that produced wrong initial transparency position and radius as well as tracking in y. The bug appeared as a consequence of the change of those variables from pixel based to normalized. Everything is now in normalized position and sizes.