### PR TITLE
Limit processing evets from QEventLoop when loading scene.

### DIFF
--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -944,7 +944,7 @@ void Application::StopProgress(QProgressDialog * progressDialog)
 }
 
 
-void Application::UpdateProgress( QProgressDialog * progressDialog, int current )
+void Application::UpdateProgress( QProgressDialog * progressDialog, int current, bool processEvents )
 {
     if (!progressDialog) // the process might have been cancelled
         return;
@@ -952,7 +952,9 @@ void Application::UpdateProgress( QProgressDialog * progressDialog, int current 
         progressDialog->reset();
     else
         progressDialog->setValue( current );
-    QApplication::processEvents();
+
+    if( processEvents )
+        QApplication::processEvents();
 }
 
 void Application::ShowMinc1Warning( bool cando)

--- a/IbisLib/application.h
+++ b/IbisLib/application.h
@@ -171,7 +171,7 @@ public:
     void ShowMinc1Warning( bool cando);
 
 public slots:
-    void UpdateProgress( QProgressDialog*, int current );
+    void UpdateProgress( QProgressDialog*, int current, bool processEvents = true );
 
 private slots:
 

--- a/IbisLib/gui/quadviewwindow.cpp
+++ b/IbisLib/gui/quadviewwindow.cpp
@@ -223,7 +223,7 @@ void QuadViewWindow::SetSceneManager( SceneManager * man )
 
         connect (m_sceneManager, SIGNAL(ExpandView()), this, SLOT(ExpandViewButtonClicked()));
         m_sceneManager->PreDisplaySetup();
-        this->PlaceCornerText();
+//        this->PlaceCornerText(); temporarily blocked until
     }
 }
 
@@ -279,7 +279,8 @@ void QuadViewWindow::Win3NeedsRender() { this->WinNeedsRender( 3 ); }
 
 void QuadViewWindow::WinNeedsRender( int winIndex )
 {
-    m_vtkWindows[ winIndex ]->update();
+    if( !m_sceneManager->IsLoadingScene() )
+        m_vtkWindows[ winIndex ]->update();
 }
 
 void QuadViewWindow::ZoomInButtonClicked()
@@ -311,9 +312,12 @@ void QuadViewWindow::ZoomCameraButtonClicked()
 
 void QuadViewWindow::RenderAll()
 {
-    for( int i = 0; i < 4; i++ )
+    if( !m_sceneManager->IsLoadingScene() )
     {
-        m_vtkWindows[i]->update();
+        for( int i = 0; i < 4; i++ )
+        {
+            m_vtkWindows[i]->update();
+        }
     }
 }
 

--- a/IbisLib/gui/quadviewwindow.cpp
+++ b/IbisLib/gui/quadviewwindow.cpp
@@ -223,7 +223,7 @@ void QuadViewWindow::SetSceneManager( SceneManager * man )
 
         connect (m_sceneManager, SIGNAL(ExpandView()), this, SLOT(ExpandViewButtonClicked()));
         m_sceneManager->PreDisplaySetup();
-//        this->PlaceCornerText(); temporarily blocked until
+//        this->PlaceCornerText(); temporarily blocked
     }
 }
 
@@ -231,15 +231,10 @@ void QuadViewWindow::AddBottomWidget( QWidget * w )
 {
     w->setParent( m_bottomWidgetFrame );
     m_bottomWidgetLayout->addWidget( w );
-    //w->setMinimumHeight( 50 );
-    //w->show();
-    //m_generalLayout->addWidget( w );
 }
 
 void QuadViewWindow::RemoveBottomWidget( QWidget * w )
 {
-    //w->setParent( 0 );
-    //m_generalLayout->removeWidget( w );
     w->close();
 }
 

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -296,8 +296,9 @@ void SceneManager::LoadScene( QString & fileName, bool interactive )
     }
     else if( reader.FileVersionIsLowerThan( QString::number(6.0) ) )
     {
-        QString message = "This scene version is older than 6.0. This is not supported anymore. Scene may not be correctly restored.\n";
+        QString message = "This scene version is older than 6.0. This is not supported anymore. Scene may not be restored.\n";
         QMessageBox::warning( 0, "Error", message, 1, 0 );
+        return;
     }
     int numberOfSceneObjects;
     ::Serialize( &reader, "NumberOfSceneObjects", numberOfSceneObjects );
@@ -1312,7 +1313,6 @@ void SceneManager::ObjectReader( Serializer * ser, bool interactive )
 
     for (i = 0; i < numberOfSceneObjects; i++)
     {
-        QString objectName;
         QString sectionName = QString( "ObjectInScene_%1" ).arg(i);
         ser->BeginSection( sectionName.toUtf8().data() );
         ::Serialize( ser, "ObjectClass", className );

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -227,7 +227,6 @@ void SceneManager::ClearScene()
 
     // Make sure everything is updated
     Application::GetInstance().UpdateProgress(progressDialog, 4);
-    QApplication::processEvents();
 
     NotifyPluginsSceneFinishedLoading();
 
@@ -306,14 +305,17 @@ void SceneManager::LoadScene( QString & fileName, bool interactive )
 
     // Start Progress dialog
     if( interactive )
+    {
+        QApplication::processEvents();
         m_sceneLoadSaveProgressDialog = Application::GetInstance().StartProgress( numberOfSceneObjects*2+3, tr("Loading Scene...") );
+    }
 
     this->ObjectReader(&reader, interactive);
-    if( interactive && !this->UpdateProgress(numberOfSceneObjects+1) )
+    if( interactive && !this->UpdateProgress(numberOfSceneObjects+1, false ) )
         return;
     ::Serialize( &reader, "SceneManager", this );
     SceneObject *currentObject = this->GetCurrentObject();
-    if( interactive && !this->UpdateProgress(numberOfSceneObjects+1) )
+    if( interactive && !this->UpdateProgress(numberOfSceneObjects+1), false )
         return;
 
     // Read other params of the scene
@@ -326,7 +328,7 @@ void SceneManager::LoadScene( QString & fileName, bool interactive )
     reader.EndSection();
     reader.Finish();
     this->SetSceneFile( fileName );
-    if( interactive && !this->UpdateProgress(numberOfSceneObjects+3) )
+    if( interactive && !this->UpdateProgress(numberOfSceneObjects+3, false ) )
         return;
 
     // Give a chance to all objects to react after scene is read
@@ -362,7 +364,7 @@ void SceneManager::CancelProgress()
     this->ClearScene();
 }
 
-bool SceneManager::UpdateProgress(int value)
+bool SceneManager::UpdateProgress(int value, int processEvents)
 {
     if (!m_sceneLoadSaveProgressDialog)
         return false;
@@ -371,8 +373,7 @@ bool SceneManager::UpdateProgress(int value)
         this->CancelProgress();
         return false;
     }
-    QApplication::processEvents();
-    Application::GetInstance().UpdateProgress(m_sceneLoadSaveProgressDialog, value);
+    Application::GetInstance().UpdateProgress(m_sceneLoadSaveProgressDialog, value, processEvents );
     return true;
 }
 
@@ -1464,7 +1465,7 @@ void SceneManager::ObjectReader( Serializer * ser, bool interactive )
             }
         }
         ser->EndSection();
-        if ( interactive && !this->UpdateProgress(i+1) )
+        if ( interactive && !this->UpdateProgress(i+1), false )
             return;
     }
     ser->EndSection();
@@ -1479,7 +1480,7 @@ void SceneManager::ObjectReader( Serializer * ser, bool interactive )
         if( sectionFound )
             ser->EndSection();
         // simtodo : THIS IS WEIRD!! (Anka: yes, it is, interactive is always true in current version, it is prepared for some background scene loading, maybe should be discarded?)
-        if( interactive && !this->UpdateProgress(++i) )
+        if( interactive && !this->UpdateProgress(++i), false )
             return;
     }
     ser->EndSection();

--- a/IbisLib/scenemanager.h
+++ b/IbisLib/scenemanager.h
@@ -362,7 +362,7 @@ protected:
 
     // scene loading/saving progress
     QProgressDialog *m_sceneLoadSaveProgressDialog;
-    bool UpdateProgress(int value);
+    bool UpdateProgress(int value, int processEvents = true );
 
     QStringList TemporaryFiles;
 

--- a/IbisLib/usacquisitionobject.cpp
+++ b/IbisLib/usacquisitionobject.cpp
@@ -621,7 +621,6 @@ bool USAcquisitionObject::LoadFramesFromMINCFile( QStringList & allMINCFiles )
             localTransform->Delete();
 
             progress->setValue(i);
-            qApp->processEvents();
             if ( progress->wasCanceled() )
             {
                 QMessageBox::information(0, "Importing frames", "Process cancelled", 1, 0);


### PR DESCRIPTION
Also, don't render during while loading scene.
