### PR TITLE
Animate plugin: fix offscreen rendering

### DIFF
--- a/IbisPlugins/Animate/animateplugininterface.h
+++ b/IbisPlugins/Animate/animateplugininterface.h
@@ -30,7 +30,7 @@ class QTime;
 // This is a hack that allows to tell the volume renderer that
 // the size of the render surface is not that of the window
 // because we render to a texture.
-class AnimateRenderState : public vtkIbisRenderState
+class DomeRenderState : public vtkIbisRenderState
 {
 public:
     virtual void GetRenderSize( vtkRenderer * ren, int size[2] );
@@ -130,7 +130,7 @@ protected:
 
     bool m_renderDome;
     DomeRenderer * m_domeRenderDelegate;
-    AnimateRenderState * m_renderState;
+    DomeRenderState * m_renderState;
     TimelineWidget * m_timelineWidget;
 
     int m_renderSize[2];

--- a/IbisPlugins/Animate/animatewidget.cpp
+++ b/IbisPlugins/Animate/animatewidget.cpp
@@ -71,7 +71,9 @@ void AnimateWidget::UpdateUi()
     // Render
     int size = m_pluginInterface->GetRenderSize()[0];
     ui->renderSizeButtonGroup->blockSignals( true );
-    if( size == 1024 )
+    if( size == 1920 )
+        ui->renderHDRadioButton->setChecked( true );
+    else if( size == 1024 )
         ui->render1KradioButton->setChecked( true );
     else if( size == 2048 )
         ui->render2KRadioButton->setChecked( true );
@@ -134,6 +136,13 @@ void AnimateWidget::on_cameraKeyCheckBox_toggled( bool checked )
 {
     Q_ASSERT( m_pluginInterface );
     m_pluginInterface->SetCameraKey( checked );
+}
+
+void AnimateWidget::on_renderHDRadioButton_toggled(bool checked)
+{
+    Q_ASSERT( m_pluginInterface );
+    if( checked )
+        m_pluginInterface->SetRenderSize( 1920, 1080 );
 }
 
 void AnimateWidget::on_render1KradioButton_toggled(bool checked)
@@ -231,3 +240,4 @@ void AnimateWidget::on_domeViewAngleSpinBox_valueChanged(int arg1)
     m_pluginInterface->SetDomeViewAngle( arg1 );
     UpdateUi();
 }
+

--- a/IbisPlugins/Animate/animatewidget.h
+++ b/IbisPlugins/Animate/animatewidget.h
@@ -44,6 +44,7 @@ private slots:
     void on_cubeTextureSizeSlider_valueChanged(int value);
     void on_cubeTextureSizeSpinBox_valueChanged(int arg1);
     void on_cameraKeyCheckBox_toggled(bool checked);
+    void on_renderHDRadioButton_toggled(bool checked);
     void on_render1KradioButton_toggled(bool checked);
     void on_render2KRadioButton_toggled(bool checked);
     void on_render4KradioButton_toggled(bool checked);

--- a/IbisPlugins/Animate/animatewidget.ui
+++ b/IbisPlugins/Animate/animatewidget.ui
@@ -205,6 +205,16 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
+         <widget class="QRadioButton" name="renderHDRadioButton">
+          <property name="text">
+           <string>HD</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">renderSizeButtonGroup</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
          <widget class="QRadioButton" name="render1KradioButton">
           <property name="minimumSize">
            <size>

--- a/IbisPlugins/Animate/vtkOffscreenCamera.cxx
+++ b/IbisPlugins/Animate/vtkOffscreenCamera.cxx
@@ -126,7 +126,8 @@ void vtkOffscreenCamera::Render(vtkRenderer *ren)
   glMatrixMode( GL_PROJECTION);
   if(usize && vsize)
   {
-      matrix->DeepCopy(this->GetProjectionTransformMatrix( usize/vsize, -1,1 ) );
+      double ratio = ((double)usize) / vsize;
+      matrix->DeepCopy(this->GetProjectionTransformMatrix( ratio, -1,1 ) );
       matrix->Transpose();
   }
 


### PR DESCRIPTION
Fixed bug that caused Offscreen rendering to produce deformed results when render size > screen size for volume rendering when not in dome mode because volume renderer used window resolution. Also: added new rendering resolution (HD 1920x1080).