### PR TITLE
Disallow removing and disabling points when only 3 active points remain.

### DIFF
--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -397,12 +397,6 @@ void LandmarkRegistrationObject::SetPointEnabledStatus (int index, int stat )
     this->UpdateLandmarkTransform();
 }
 
-void LandmarkRegistrationObject::DeleteAllPoints()
-{
-    for( int i = GetNumberOfPoints() - 1; i >= 0; --i )
-        DeletePoint( i );
-}
-
 void LandmarkRegistrationObject::DeletePoint( int index )
 {
     m_sourcePoints->RemovePoint( index );
@@ -417,7 +411,8 @@ void LandmarkRegistrationObject::DeletePoint( int index )
     {
         m_activePointNames.append(names->at(i));
     }
-    this->UpdateLandmarkTransform();
+    if( m_sourcePoints->GetNumberOfPoints() > 2 )
+        this->UpdateLandmarkTransform();
 }
 
 void LandmarkRegistrationObject::SelectPoint( int index )

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -411,7 +411,7 @@ void LandmarkRegistrationObject::DeletePoint( int index )
     {
         m_activePointNames.append(names->at(i));
     }
-    if( m_sourcePoints->GetNumberOfPoints() > 2 )
+    if( this->GetNumberOfActivePoints() > 2 )
         this->UpdateLandmarkTransform();
 }
 

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
@@ -44,6 +44,7 @@ public:
     PointsObject *GetTargetPoints() { return m_targetPoints; }
     QStringList GetPointNames( );
     int  GetNumberOfPoints();
+    int  GetNumberOfActivePoints() { return m_activeSourcePoints->GetNumberOfPoints(); }
     LandmarkTransform *GetLandmarkTransform() { return m_registrationTransform; }
     void UpdateLandmarkTransform();
     void RegisterObject( bool on );
@@ -54,7 +55,6 @@ public:
     void SetTargetObjectID( int id );
     int  GetPointEnabledStatus( int index );
     void SetPointEnabledStatus (int index, int stat );
-    void DeleteAllPoints();
     void DeletePoint( int index );
     void SelectPoint( int index );
     void SetPointLabel( int index, const QString & label );

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
@@ -27,6 +27,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QContextMenuEvent>
 #include <QPalette>
 #include <QDateTime>
+#include <QMessageBox>
 
 LandmarkRegistrationObjectSettingsWidget::LandmarkRegistrationObjectSettingsWidget(QWidget *parent) :
     QWidget(parent),
@@ -189,6 +190,11 @@ void LandmarkRegistrationObjectSettingsWidget::contextMenuEvent( QContextMenuEve
 {
     if ( !ui->pointsTreeView->hasFocus() )
         return;
+    if( m_registrationObject->GetNumberOfActivePoints() < 4 )
+    {
+        QMessageBox::warning( 0, "Warning", "There are 3 active points left.\nRemoving or disabling point is not allowed.", 1, 0 );
+        return;
+    }
     Q_ASSERT(m_registrationObject);
     QModelIndex currentIndex = ui->pointsTreeView->currentIndex();
     if (currentIndex.isValid())

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
@@ -27,7 +27,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QContextMenuEvent>
 #include <QPalette>
 #include <QDateTime>
-#include <QMessageBox>
 
 LandmarkRegistrationObjectSettingsWidget::LandmarkRegistrationObjectSettingsWidget(QWidget *parent) :
     QWidget(parent),
@@ -190,11 +189,6 @@ void LandmarkRegistrationObjectSettingsWidget::contextMenuEvent( QContextMenuEve
 {
     if ( !ui->pointsTreeView->hasFocus() )
         return;
-    if( m_registrationObject->GetNumberOfActivePoints() < 4 )
-    {
-        QMessageBox::warning( 0, "Warning", "There are 3 active points left.\nRemoving or disabling point is not allowed.", 1, 0 );
-        return;
-    }
     Q_ASSERT(m_registrationObject);
     QModelIndex currentIndex = ui->pointsTreeView->currentIndex();
     if (currentIndex.isValid())
@@ -295,8 +289,7 @@ void LandmarkRegistrationObjectSettingsWidget::UpdateUI()
     }
     ui->registerPushButton->blockSignals( false );
 
-    int numberOfPoints = m_registrationObject->GetNumberOfPoints();
-    if( numberOfPoints >  3  && rms > 0 ) // we never expect perfect match (rms == 0), should we?
+    if( m_registrationObject->GetNumberOfActivePoints() >  2  && rms > 0 ) // we never expect perfect match (rms == 0), should we?
         ui->registerPushButton->setEnabled( true );
     else
         ui->registerPushButton->setEnabled( false );
@@ -308,7 +301,7 @@ void LandmarkRegistrationObjectSettingsWidget::UpdateUI()
     QColor disabled("gray");
     QBrush brush(disabled);
     int activePointsCount = 0;
-    for (int idx = 0; idx < numberOfPoints; idx++)
+    for (int idx = 0; idx < m_registrationObject->GetNumberOfPoints(); idx++)
     {
         m_model->insertRow(idx);
         m_model->setData(m_model->index(idx, 0), m_registrationObject->GetPointNames().at(idx));


### PR DESCRIPTION
vtkLandmarkRegistration is not defined when there are less than 3 points. User who wants to remove last 3 points should remove LandmarkRegostrationObject and start from scratch.