### PR TITLE
Removed usage of TripleCutPlaneObject in all other objects except SceneManager. 

### DIFF
--- a/Ibis/mainwindow.cpp
+++ b/Ibis/mainwindow.cpp
@@ -19,7 +19,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "opendatafiledialog.h"
 #include "filereader.h"
 #include "worldobject.h"
-#include "triplecutplaneobject.h"
 #include "ibisconfig.h"
 #include "toolplugininterface.h"
 #include "objectplugininterface.h"
@@ -359,31 +358,31 @@ void MainWindow::NewPointSet()
 void MainWindow::ViewXPlaneToggled(bool viewOn)
 {
     SceneManager * manager = Application::GetSceneManager();
-    manager->GetMainImagePlanes()->SetViewPlane( 0, viewOn );
+    manager->ViewPlane( 0, viewOn );
 }
 
 void MainWindow::ViewYPlaneToggled(bool viewOn)
 {
     SceneManager * manager = Application::GetSceneManager();
-    manager->GetMainImagePlanes()->SetViewPlane( 1, viewOn );
+    manager->ViewPlane( 1, viewOn );
 }
 
 void MainWindow::ViewZPlaneToggled(bool viewOn)
 {
     SceneManager * manager = Application::GetSceneManager();
-    manager->GetMainImagePlanes()->SetViewPlane( 2, viewOn );
+    manager->ViewPlane( 2, viewOn );
 }
 
 void MainWindow::ViewAllPlanes()
 {
     SceneManager * manager = Application::GetSceneManager();
-    manager->GetMainImagePlanes()->SetViewAllPlanes( 1 );
+    manager->ViewAllPlanes( 1 );
 }
 
 void MainWindow::HideAllPlanes()
 {
     SceneManager * manager = Application::GetSceneManager();
-    manager->GetMainImagePlanes()->SetViewAllPlanes( 0 );
+    manager->ViewAllPlanes( 0 );
 }
 
 void MainWindow::View3DFront( )
@@ -501,9 +500,9 @@ void MainWindow::FileGenerateMenuAboutToShow()
 void MainWindow::ModifyViewMenu()
 {
     SceneManager * manager = Application::GetSceneManager();
-    m_viewXPlaneAction->setChecked(manager->GetMainImagePlanes()->GetViewPlane(0));
-    m_viewYPlaneAction->setChecked(manager->GetMainImagePlanes()->GetViewPlane(1));
-    m_viewZPlaneAction->setChecked(manager->GetMainImagePlanes()->GetViewPlane(2));
+    m_viewXPlaneAction->setChecked(manager->IsPlaneVisible(0));
+    m_viewYPlaneAction->setChecked(manager->IsPlaneVisible(1));
+    m_viewZPlaneAction->setChecked(manager->IsPlaneVisible(2));
 }
 
 void MainWindow::fileSaveScene()

--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -29,7 +29,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "toolplugininterface.h"
 #include "globalobjectplugininterface.h"
 #include "generatorplugininterface.h"
-#include "triplecutplaneobject.h"
 #include "filereader.h"
 #include "imageobject.h"
 #include "lookuptablemanager.h"
@@ -168,12 +167,12 @@ void Application::Init( bool viewerOnly )
     m_sceneManager->SetExpandedView(m_settings.ExpandedView);
     m_sceneManager->Set3DInteractorStyle( m_settings.InteractorStyle3D );
 
-    m_sceneManager->GetMainImagePlanes()->SetCursorVisibility( m_settings.ShowCursor );
-    m_sceneManager->GetMainImagePlanes()->SetViewPlane( 0, m_settings.ShowXPlane );
-    m_sceneManager->GetMainImagePlanes()->SetViewPlane( 1, m_settings.ShowYPlane );
-    m_sceneManager->GetMainImagePlanes()->SetViewPlane( 2, m_settings.ShowZPlane );
-    m_sceneManager->GetMainImagePlanes()->SetDisplayInterpolationType( m_settings.TripleCutPlaneDisplayInterpolationType );
-    m_sceneManager->GetMainImagePlanes()->SetResliceInterpolationType( m_settings.TripleCutPlaneResliceInterpolationType );
+    m_sceneManager->SetCursorVisibility( m_settings.ShowCursor );
+    m_sceneManager->ViewPlane( 0, m_settings.ShowXPlane );
+    m_sceneManager->ViewPlane( 1, m_settings.ShowYPlane );
+    m_sceneManager->ViewPlane( 2, m_settings.ShowZPlane );
+    m_sceneManager->SetDisplayInterpolationType( m_settings.TripleCutPlaneDisplayInterpolationType );
+    m_sceneManager->SetResliceInterpolationType( m_settings.TripleCutPlaneResliceInterpolationType );
 
     m_sceneManager->GetAxesObject()->SetHidden( !m_settings.ShowAxes );
 
@@ -205,14 +204,14 @@ Application::~Application()
     m_settings.ExpandedView = m_sceneManager->GetExpandedView();
     m_settings.InteractorStyle3D = m_sceneManager->Get3DInteractorStyle();
     m_settings.CameraViewAngle3D = m_sceneManager->Get3DCameraViewAngle();
-    m_settings.ShowCursor = m_sceneManager->GetMainImagePlanes()->GetCursorVisible();
+    m_settings.ShowCursor = m_sceneManager->GetCursorVisible();
     m_settings.ShowAxes = !m_sceneManager->GetAxesObject()->IsHidden();
     m_settings.ViewFollowsReference = m_sceneManager->Is3DViewFollowingReferenceVolume();
-    m_settings.ShowXPlane = m_sceneManager->GetMainImagePlanes()->GetViewPlane( 0 );
-    m_settings.ShowYPlane = m_sceneManager->GetMainImagePlanes()->GetViewPlane( 1 );
-    m_settings.ShowZPlane = m_sceneManager->GetMainImagePlanes()->GetViewPlane( 2 );
-    m_settings.TripleCutPlaneDisplayInterpolationType = m_sceneManager->GetMainImagePlanes()->GetDisplayInterpolationType();
-    m_settings.TripleCutPlaneResliceInterpolationType = m_sceneManager->GetMainImagePlanes()->GetResliceInterpolationType();
+    m_settings.ShowXPlane = m_sceneManager->IsPlaneVisible( 0 );
+    m_settings.ShowYPlane = m_sceneManager->IsPlaneVisible( 1 );
+    m_settings.ShowZPlane = m_sceneManager->IsPlaneVisible( 2 );
+    m_settings.TripleCutPlaneDisplayInterpolationType = m_sceneManager->GetDisplayInterpolationType();
+    m_settings.TripleCutPlaneResliceInterpolationType = m_sceneManager->GetResliceInterpolationType();
 
     if( !m_viewerOnly )
     {

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -420,12 +420,6 @@ void ImageObject::Setup( View * view )
     this->SetViewOutline(this->viewOutline);
 }
 
-void ImageObject::PreDisplaySetup()
-{
-    Q_ASSERT( this->GetManager() );
-    this->GetManager()->GetMainImagePlanes()->PreDisplaySetup();
-}
-
 void ImageObject::Release( View * view )
 {
     SceneObject::Release( view );
@@ -708,7 +702,7 @@ void ImageObject::SetLut(vtkScalarsToColors *lut)
             this->Lut->Register(0);
         }
     }
-    emit LutChanged();
+    emit LutChanged( this->GetObjectID() );
     emit Modified();
 }
 
@@ -744,10 +738,6 @@ int ImageObject::ChooseColorTable(int index)
         this->SetLut( lut );
         lut->Delete();
     }
-
-	// Tell the main cut planes to change the lookup table
-
-    this->GetManager()->GetMainImagePlanes()->UpdateLut( this->GetObjectID() );
 
     emit Modified();
     return 1;

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -33,7 +33,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "imageobjectsettingsdialog.h"
 #include "imageobjectvolumesettingswidget.h"
 #include "scenemanager.h"
-#include "triplecutplaneobject.h"
 #include "lookuptablemanager.h"
 #include <QMessageBox>
 
@@ -809,18 +808,14 @@ void ImageObject::Hide()
 	}
 	else
 		this->outlineWasVisible = 0;
-    if( this->GetManager() )
-        this->GetManager()->GetMainImagePlanes()->SetImageHidden( this->GetObjectID(), true );
-    emit Modified();
+    emit VisibilityChanged( this->GetObjectID() );
 }
 
 void ImageObject::Show()
 {
 	if( !this->viewOutline && this->outlineWasVisible )
 		this->SetViewOutline(1);
-    if( this->GetManager() )
-        this->GetManager()->GetMainImagePlanes()->SetImageHidden( this->GetObjectID(), false );
-    emit Modified();
+    emit VisibilityChanged( this->GetObjectID() );
 }
 
 #include "mincinfowidget.h"

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -425,7 +425,6 @@ void ImageObject::Release( View * view )
     SceneObject::Release( view );
 
     Q_ASSERT( this->GetManager() );
-    this->GetManager()->GetMainImagePlanes()->RemoveImage( this->GetObjectID() );
 
     switch( view->GetType() )
     {

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -94,7 +94,6 @@ ImageObject::ImageObject()
     this->OutlineFilter = vtkOutlineFilter::New();
     this->viewOutline = 0;
     this->outlineWasVisible = 0;
-    this->viewError = 0;
 	this->lutIndex = -1;
     this->lutRange[0] = 0.0;
     this->lutRange[1] = 0.0;
@@ -593,16 +592,6 @@ void ImageObject::SetViewOutline( int isOn )
 int ImageObject::GetViewOutline()
 {
     return this->viewOutline;
-}
-
-void ImageObject::ResetViewError( )
-{
-    this->viewError = 0;
-}
-
-int ImageObject::GetViewError()
-{
-    return this->viewError;
 }
 
 #include "vtkImageShiftScale.h"

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -401,12 +401,6 @@ void ImageObject::Setup( View * view )
 {
     SceneObject::Setup( view );
 
-    TripleCutPlaneObject * mainPlane = this->GetManager()->GetMainImagePlanes();
-    Q_ASSERT( mainPlane );
-    mainPlane->AddImage( this->GetObjectID() );
-    connect( this, SIGNAL(Modified()), mainPlane, SLOT(MarkModified()) );  // This is to make sure transforms update the reslice - simtodo : find better solution.
-    mainPlane->Setup( view );
-
     switch( view->GetType() )
     {
         case SAGITTAL_VIEW_TYPE:

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -96,7 +96,6 @@ public:
     virtual void ObjectAddedToScene();
     virtual void Setup( View * view );
     virtual void Release( View * view );
-    virtual void PreDisplaySetup();
     virtual void CreateSettingsWidgets( QWidget * parent, QVector <QWidget*> *widgets);
 
     void SetViewOutline( int isOn );
@@ -137,7 +136,7 @@ public:
 
 signals:
 
-    void LutChanged();
+    void LutChanged( int );
     
 protected:
     

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -137,7 +137,8 @@ public:
 signals:
 
     void LutChanged( int );
-    
+    void VisibilityChanged( int );
+
 protected:
     
     virtual void Hide();

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -101,8 +101,6 @@ public:
 
     void SetViewOutline( int isOn );
     int GetViewOutline();
-    void ResetViewError( );
-    int GetViewError();
 
 	// Choose from the set of lookup table templates available from the SceneManager
     int ChooseColorTable(int index);
@@ -178,7 +176,6 @@ protected:
     
     int viewOutline;
     int outlineWasVisible;
-    int viewError;
     int lutIndex;
     double lutRange[2];
     double intensityFactor;

--- a/IbisLib/pointcloudobject.cpp
+++ b/IbisLib/pointcloudobject.cpp
@@ -21,7 +21,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "pointcloudobjectsettingsdialog.h"
 #include "application.h"
 #include "scenemanager.h"
-#include "triplecutplaneobject.h"
 #include "imageobject.h"
 #include "vtkProbeFilter.h"
 

--- a/IbisLib/polydataobject.cpp
+++ b/IbisLib/polydataobject.cpp
@@ -32,7 +32,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "polydataobjectsettingsdialog.h"
 #include "application.h"
 #include "scenemanager.h"
-#include "triplecutplaneobject.h"
 #include "imageobject.h"
 #include "vtkProbeFilter.h"
 #include "vtkClipPolyData.h"

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -642,6 +642,73 @@ void SceneManager::AddObjectUsingID( SceneObject * object, SceneObject * attachT
     }
 }
 
+bool SceneManager::GetCursorVisible()
+{
+    Q_ASSERT( MainCutPlanes );
+    return MainCutPlanes->GetCursorVisible();
+}
+
+void SceneManager::SetCursorVisibility( bool v )
+{
+    Q_ASSERT( MainCutPlanes );
+    MainCutPlanes->SetCursorVisibility( v );
+}
+
+void SceneManager::SetCursorColor( const QColor & c )
+{
+    Q_ASSERT( MainCutPlanes );
+    MainCutPlanes->SetCursorColor( c );
+}
+
+QColor SceneManager::GetCursorColor()
+{
+    Q_ASSERT( MainCutPlanes );
+    return MainCutPlanes->GetCursorColor();
+}
+
+void SceneManager::ViewPlane( int index, bool show )
+{
+    Q_ASSERT( MainCutPlanes );
+    MainCutPlanes->SetViewPlane( index, show );
+}
+
+bool SceneManager::IsPlaneVisible( int index )
+{
+    Q_ASSERT( MainCutPlanes );
+    return MainCutPlanes->GetViewPlane( index );
+}
+
+void SceneManager::ViewAllPlanes( bool show )
+{
+    Q_ASSERT( MainCutPlanes );
+    MainCutPlanes->SetViewAllPlanes( show );
+}
+
+void SceneManager::SetResliceInterpolationType( int type )
+{
+    Q_ASSERT( MainCutPlanes );
+    MainCutPlanes->SetResliceInterpolationType( type );
+}
+
+int SceneManager::GetResliceInterpolationType()
+{
+    Q_ASSERT( MainCutPlanes );
+    return MainCutPlanes->GetResliceInterpolationType();
+}
+
+void SceneManager::SetDisplayInterpolationType( int type )
+{
+    Q_ASSERT( MainCutPlanes );
+    MainCutPlanes->SetDisplayInterpolationType( type );
+}
+
+int SceneManager::GetDisplayInterpolationType()
+{
+    Q_ASSERT( MainCutPlanes );
+    return MainCutPlanes->GetDisplayInterpolationType();
+}
+
+
 void SceneManager::RemoveObjectById( int objectId )
 {
     SceneObject * obj = GetObjectByID( objectId );

--- a/IbisLib/scenemanager.h
+++ b/IbisLib/scenemanager.h
@@ -25,6 +25,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "sceneobject.h"
 #include "serializer.h"
 #include "view.h"
+#include <QColor>
 
 class QWidget;
 class QStringList;
@@ -178,6 +179,21 @@ public:
     void GetAllTrackedObjects( QList<TrackedSceneObject*> & all );
     void GetAllObjectsOfType( const char * typeName, QList<SceneObject*> & all );
 
+    // Manage cursor visibility and color - wrapper for TrippleCutPlane
+    bool GetCursorVisible();
+    void SetCursorVisibility( bool v );
+    void SetCursorColor( const QColor & c );
+    QColor GetCursorColor();
+    // Manage planes visibility - wrapper for TrippleCutPlane
+    void ViewPlane( int index, bool show );
+    bool IsPlaneVisible( int index );
+    void ViewAllPlanes( bool show );
+    // Manage data interpolation for reslice and display - wrapper for TrippleCutPlane
+    void SetResliceInterpolationType( int type );
+    int GetResliceInterpolationType();
+    void SetDisplayInterpolationType( int type );
+    int GetDisplayInterpolationType();
+
     // Description:
     // Get object by ID
     SceneObject * GetObjectByID( int id );
@@ -216,6 +232,10 @@ public:
     // initialize new Views.
     void SetupAllObjects( View * v );
     void ReleaseAllObjects( View * v );
+
+    // Description:
+    // Utility function to setup an object in all views
+    void SetupInAllViews( SceneObject * object );
 
     // Description:
     // Utility function to detach all views from the render window.
@@ -332,7 +352,7 @@ protected:
 
     // Description:
     // Utility function to setup an object in all views
-    void SetupInAllViews( SceneObject * object );
+//    void SetupInAllViews( SceneObject * object );
 
     // Description:
     // Recursive function used to setup all objects bellow obj

--- a/IbisLib/scenemanager.h
+++ b/IbisLib/scenemanager.h
@@ -351,10 +351,6 @@ protected:
     void AddObjectUsingID( SceneObject * object, SceneObject * attachTo = 0, int objID = SceneObject::InvalidObjectId);
 
     // Description:
-    // Utility function to setup an object in all views
-//    void SetupInAllViews( SceneObject * object );
-
-    // Description:
     // Recursive function used to setup all objects bellow obj
     // in view v.
     void SetupOneObject( View * v, SceneObject * obj );

--- a/IbisLib/triplecutplaneobject.cpp
+++ b/IbisLib/triplecutplaneobject.cpp
@@ -327,10 +327,10 @@ void TripleCutPlaneObject::ObjectAddedSlot( int objectId )
 void TripleCutPlaneObject::ObjectRemovedSlot( int objectId )
 {
     Q_ASSERT( GetManager() );
-    ImageObject * img = ImageObject::SafeDownCast( this->GetManager()->GetObjectByID( objectId ) );
-    if( img )
+    ImageContainer::iterator it = std::find( Images.begin(), Images.end(), objectId );
+    if( it != Images.end() )
     {
-        disconnect( img, SIGNAL(Modified()), this, SLOT(MarkModified()) );
+        this->RemoveImage( objectId );
     }
 }
 

--- a/IbisLib/triplecutplaneobject.cpp
+++ b/IbisLib/triplecutplaneobject.cpp
@@ -321,6 +321,7 @@ void TripleCutPlaneObject::ObjectAddedSlot( int objectId )
         this->PreDisplaySetup();
         connect( img, SIGNAL(Modified()), this, SLOT(MarkModified()) );
         connect( img, SIGNAL(LutChanged( int )), this, SLOT(UpdateLut( int )) );
+        connect( img, SIGNAL(VisibilityChanged( int )), this, SLOT(SetImageHidden( int )) );
     }
 }
 
@@ -343,11 +344,12 @@ void TripleCutPlaneObject::UpdateLut(int imageID )
     }
 }
 
-void TripleCutPlaneObject::SetImageHidden( int imageID, bool hidden )
+void TripleCutPlaneObject::SetImageHidden( int imageID )
 {
     ImageObject * im = ImageObject::SafeDownCast( this->GetManager()->GetObjectByID( imageID ) );
     for( int i = 0; i < 3; ++i )
-        this->Planes[i]->SetImageHidden( im->GetImage(), hidden );
+        this->Planes[i]->SetImageHidden( im->GetImage(), im->IsHidden() );
+    this->MarkModified();
 }
 
 void TripleCutPlaneObject::PreDisplaySetup()

--- a/IbisLib/triplecutplaneobject.cpp
+++ b/IbisLib/triplecutplaneobject.cpp
@@ -320,6 +320,7 @@ void TripleCutPlaneObject::ObjectAddedSlot( int objectId )
         this->GetManager()->SetupInAllViews( this );
         this->PreDisplaySetup();
         connect( img, SIGNAL(Modified()), this, SLOT(MarkModified()) );
+        connect( img, SIGNAL(LutChanged( int )), this, SLOT(UpdateLut( int )) );
     }
 }
 

--- a/IbisLib/triplecutplaneobject.cpp
+++ b/IbisLib/triplecutplaneobject.cpp
@@ -316,9 +316,10 @@ void TripleCutPlaneObject::ObjectAddedSlot( int objectId )
     ImageObject * img = ImageObject::SafeDownCast( this->GetManager()->GetObjectByID( objectId ) );
     if( img )
     {
-//        this->GetManager()->SetupInAllViews( this );
-//        this->AddImage( objectId );
-//        connect( img, SIGNAL(Modified()), this, SLOT(MarkModified()) );
+        this->AddImage( objectId );
+        this->GetManager()->SetupInAllViews( this );
+        this->PreDisplaySetup();
+        connect( img, SIGNAL(Modified()), this, SLOT(MarkModified()) );
     }
 }
 

--- a/IbisLib/triplecutplaneobject.cpp
+++ b/IbisLib/triplecutplaneobject.cpp
@@ -296,6 +296,42 @@ void TripleCutPlaneObject::AdjustAllImages()
     }
 }
 
+void TripleCutPlaneObject::ObjectAddedToScene()
+{
+    Q_ASSERT( GetManager() );
+    connect( GetManager(), SIGNAL(ObjectAdded(int)), this, SLOT(ObjectAddedSlot(int)) );
+    connect( GetManager(), SIGNAL(ObjectRemoved(int)), this, SLOT(ObjectRemovedSlot(int)) );
+}
+
+void TripleCutPlaneObject::ObjectRemovedFromScene()
+{
+    Q_ASSERT( GetManager() );
+    disconnect( GetManager(), SIGNAL(ObjectAdded(int)), this, SLOT(ObjectAddedSlot(int)) );
+    disconnect( GetManager(), SIGNAL(ObjectRemoved(int)), this, SLOT(ObjectRemovedSlot(int)) );
+}
+
+void TripleCutPlaneObject::ObjectAddedSlot( int objectId )
+{
+    Q_ASSERT( GetManager() );
+    ImageObject * img = ImageObject::SafeDownCast( this->GetManager()->GetObjectByID( objectId ) );
+    if( img )
+    {
+//        this->GetManager()->SetupInAllViews( this );
+//        this->AddImage( objectId );
+//        connect( img, SIGNAL(Modified()), this, SLOT(MarkModified()) );
+    }
+}
+
+void TripleCutPlaneObject::ObjectRemovedSlot( int objectId )
+{
+    Q_ASSERT( GetManager() );
+    ImageObject * img = ImageObject::SafeDownCast( this->GetManager()->GetObjectByID( objectId ) );
+    if( img )
+    {
+        disconnect( img, SIGNAL(Modified()), this, SLOT(MarkModified()) );
+    }
+}
+
 void TripleCutPlaneObject::UpdateLut(int imageID )
 {
     ImageObject * im = ImageObject::SafeDownCast( this->GetManager()->GetObjectByID( imageID ) );

--- a/IbisLib/triplecutplaneobject.h
+++ b/IbisLib/triplecutplaneobject.h
@@ -107,7 +107,7 @@ public slots:
     void AdjustAllImages(  );
     void UpdateLut( int imageID );
     void ObjectAddedSlot( int objectId );
-    void ObjectRemovedSlot( int objectId );
+    void ObjectRemovedSlot(int objectId );
     virtual void MarkModified();
 
 signals:

--- a/IbisLib/triplecutplaneobject.h
+++ b/IbisLib/triplecutplaneobject.h
@@ -106,6 +106,8 @@ public slots:
     void PlaneEndInteractionEvent( vtkObject * caller, unsigned long event );
     // Adjust planes
     void AdjustAllImages(  );
+    void ObjectAddedSlot( int objectId );
+    void ObjectRemovedSlot( int objectId );
     virtual void MarkModified();
 
 signals:
@@ -115,6 +117,8 @@ signals:
 
 protected:
 
+    void ObjectAddedToScene();
+    void ObjectRemovedFromScene();
     View * Get3DView();
 	void Setup3DRepresentation( View * view );
 	void Release3DRepresentation( View * view );

--- a/IbisLib/triplecutplaneobject.h
+++ b/IbisLib/triplecutplaneobject.h
@@ -51,7 +51,6 @@ public:
     ImageObject * GetImage( int index );
     void AddImage( int imageID);
     void RemoveImage(int imageID );
-    void UpdateLut( int imageID);
     void SetImageHidden(int imageID, bool hidden );
 	void PreDisplaySetup();
 	void ResetPlanes();
@@ -106,6 +105,7 @@ public slots:
     void PlaneEndInteractionEvent( vtkObject * caller, unsigned long event );
     // Adjust planes
     void AdjustAllImages(  );
+    void UpdateLut( int imageID );
     void ObjectAddedSlot( int objectId );
     void ObjectRemovedSlot( int objectId );
     virtual void MarkModified();

--- a/IbisLib/triplecutplaneobject.h
+++ b/IbisLib/triplecutplaneobject.h
@@ -51,7 +51,6 @@ public:
     ImageObject * GetImage( int index );
     void AddImage( int imageID);
     void RemoveImage(int imageID );
-    void SetImageHidden(int imageID, bool hidden );
 	void PreDisplaySetup();
 	void ResetPlanes();
     vtkMultiImagePlaneWidget * GetPlane( int index ) { return (index < 3 && index >= 0) ? Planes[index] : 0; }
@@ -109,6 +108,7 @@ public slots:
     void ObjectAddedSlot( int objectId );
     void ObjectRemovedSlot(int objectId );
     virtual void MarkModified();
+    void SetImageHidden(int imageID );
 
 signals:
     void StartPlaneMoved(int);

--- a/IbisLib/worldobject.cpp
+++ b/IbisLib/worldobject.cpp
@@ -12,7 +12,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "worldobjectsettingswidget.h"
 #include "scenemanager.h"
 #include "polydataobject.h"
-#include "triplecutplaneobject.h"
 #include "application.h"
 
 WorldObject::WorldObject()
@@ -73,32 +72,32 @@ bool WorldObject::Is3DViewFollowingReferenceVolume()
 void WorldObject::SetCursorVisible( bool v )
 {
     Q_ASSERT( this->GetManager() );
-    this->GetManager()->GetMainImagePlanes()->SetCursorVisibility( v );
+    this->GetManager()->SetCursorVisibility( v );
 }
 
 bool WorldObject::GetCursorVisible()
 {
     Q_ASSERT( this->GetManager() );
-    return this->GetManager()->GetMainImagePlanes()->GetCursorVisible();
+    return this->GetManager()->GetCursorVisible();
 }
 
 void WorldObject::SetCursorColor( const QColor & c )
 {
     Q_ASSERT( this->GetManager() );
-    this->GetManager()->GetMainImagePlanes()->SetCursorColor(c);
+    this->GetManager()->SetCursorColor(c);
 }
 
 void WorldObject::SetCursorColor( double color[3] )
 {
     Q_ASSERT( this->GetManager() );
     QColor col( (int)(color[0] * 255), (int)(color[1] * 255), (int)(color[2] * 255) );
-    this->GetManager()->GetMainImagePlanes()->SetCursorColor(col);
+    this->GetManager()->SetCursorColor(col);
 }
 
 QColor WorldObject::GetCursorColor()
 {
     Q_ASSERT( this->GetManager() );
-    return this->GetManager()->GetMainImagePlanes()->GetCursorColor();
+    return this->GetManager()->GetCursorColor();
 }
 
 void WorldObject::SetBackgroundColor( const QColor & c )

--- a/IbisPlugins/USAcquisition/usacquisitionplugininterface.cpp
+++ b/IbisPlugins/USAcquisition/usacquisitionplugininterface.cpp
@@ -260,14 +260,14 @@ void USAcquisitionPluginInterface::SetCurrentVolumeObjectId( int id )
     ImageObject * prev = ImageObject::SafeDownCast( GetSceneManager()->GetObjectByID( m_currentVolumeObjectId ) );
     if( prev )
     {
-        disconnect( prev, SIGNAL(LutChanged()), this, SLOT(LutChanged()) );
+        disconnect( prev, SIGNAL(LutChanged(int)), this, SLOT(LutChanged(int)) );
         disconnect( prev, SIGNAL(Modified()), this, SLOT(OnImageChanged()));
     }
     m_currentVolumeObjectId = id;
     ImageObject * im = ImageObject::SafeDownCast( GetSceneManager()->GetObjectByID( id ) );
     if( im )
     {
-        connect( im, SIGNAL(LutChanged()), this, SLOT(LutChanged()) );
+        connect( im, SIGNAL(LutChanged(int)), this, SLOT(LutChanged(int)) );
         connect( im, SIGNAL(Modified()), this, SLOT(OnImageChanged()));
     }
 }
@@ -277,14 +277,14 @@ void USAcquisitionPluginInterface::SetAddedVolumeObjectId( int id )
     ImageObject * prev = ImageObject::SafeDownCast( GetSceneManager()->GetObjectByID( m_addedVolumeObjectId ) );
     if( prev )
     {
-        disconnect( prev, SIGNAL(LutChanged()), this, SLOT(LutChanged()) );
+        disconnect( prev, SIGNAL(LutChanged(int)), this, SLOT(LutChanged(int)) );
         disconnect( prev, SIGNAL(Modified()), this, SLOT(OnImageChanged()));
     }
     m_addedVolumeObjectId = id;
     ImageObject * im = ImageObject::SafeDownCast( GetSceneManager()->GetObjectByID( id ) );
     if( im )
     {
-        connect( im, SIGNAL(LutChanged()), this, SLOT(LutChanged()) );
+        connect( im, SIGNAL(LutChanged(int)), this, SLOT(LutChanged(int)) );
         connect( im, SIGNAL(Modified()), this, SLOT(OnImageChanged()));
     }
 }
@@ -294,7 +294,7 @@ void USAcquisitionPluginInterface::SceneContentChanged()
     ValidateAllSceneObjects();
 }
 
-void USAcquisitionPluginInterface::LutChanged()
+void USAcquisitionPluginInterface::LutChanged( int vtkNotUsed(id) )
 {
     emit ObjectsChanged();
 }

--- a/IbisPlugins/USAcquisition/usacquisitionplugininterface.h
+++ b/IbisPlugins/USAcquisition/usacquisitionplugininterface.h
@@ -83,7 +83,7 @@ signals:
 private slots:
 
     void SceneContentChanged();
-    void LutChanged();
+    void LutChanged( int );
     void OnImageChanged();
 
 protected:


### PR DESCRIPTION
Added wrapper functions to access cursor and view planes. Use signals/slots to add/remove images from/to cut planes.