### PR TITLE
PRISM volume rendering: Changed clipping strategy for near and far planes

### DIFF
--- a/IbisPlugins/PRISMVolumeRender/CMakeLists.txt
+++ b/IbisPlugins/PRISMVolumeRender/CMakeLists.txt
@@ -29,9 +29,13 @@ set( PluginSrc  PRISMVolumeRenderPluginInterface.cpp
                 volumerenderingsinglevolumesettingswidget.cpp
                 volumeshadereditorwidget.cpp
                 vtkPRISMVolumeMapper.cxx
+                vtkColoredCube.cxx
+                vtkColorPolyData.cxx
                 ${LibGlslSrc} )
 
-set( PluginHdr vtkPRISMVolumeMapper.h )
+set( PluginHdr vtkPRISMVolumeMapper.h
+                vtkColoredCube.h
+                vtkColorPolyData.h )
 
 set( PluginHdrMoc   PRISMVolumeRenderPluginInterface.h
                     volumerenderingobject.h

--- a/IbisPlugins/PRISMVolumeRender/vtkColorPolyData.cxx
+++ b/IbisPlugins/PRISMVolumeRender/vtkColorPolyData.cxx
@@ -1,0 +1,138 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    vtkColorPolyData.cxx
+
+  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+#include "vtkColorPolyData.h"
+
+#include "vtkDataSet.h"
+#include "vtkUnsignedCharArray.h"
+#include "vtkInformation.h"
+#include "vtkInformationVector.h"
+#include "vtkMath.h"
+#include "vtkObjectFactory.h"
+#include "vtkPointData.h"
+
+vtkStandardNewMacro(vtkColorPolyData);
+
+vtkColorPolyData::vtkColorPolyData()
+{
+    this->Bounds[0] = 0.0;
+    this->Bounds[1] = 1.0;
+    this->Bounds[2] = 0.0;
+    this->Bounds[3] = 1.0;
+    this->Bounds[4] = 0.0;
+    this->Bounds[5] = 1.0;
+}
+
+void vtkColorPolyData::SetBounds(const double bounds[6])
+{
+    int i = 0;
+    for (int i=0; i<6; i++)
+    {
+        if ( this->Bounds[i] != bounds[i] )
+        {
+            break;
+        }
+    }
+    if ( i >= 6 )
+    {
+        return; //same as before don't modify
+    }
+
+    for( int i = 0; i < 6; ++i )
+        this->Bounds[i] = bounds[i];
+
+    // okay, need to allocate stuff
+    this->Modified();
+}
+
+void vtkColorPolyData::SetBounds(double xmin, double xmax, double ymin, double ymax,
+                          double zmin, double zmax)
+{
+    double bounds[6];
+    bounds[0] = xmin;
+    bounds[1] = xmax;
+    bounds[2] = ymin;
+    bounds[3] = ymax;
+    bounds[4] = zmin;
+    bounds[5] = zmax;
+
+    this->SetBounds(bounds);
+}
+
+int vtkColorPolyData::RequestData(
+  vtkInformation *vtkNotUsed(request),
+  vtkInformationVector **inputVector,
+  vtkInformationVector *outputVector)
+{
+  // get the info objects
+  vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
+  vtkInformation *outInfo = outputVector->GetInformationObject(0);
+
+  // get the input and output
+  vtkDataSet *input = vtkDataSet::SafeDownCast(
+    inInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkDataSet *output = vtkDataSet::SafeDownCast(
+    outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  // First, copy the input to the output as a starting point
+  output->CopyStructure( input );
+
+  int numPts = input->GetNumberOfPoints();
+
+  //  Allocate color data
+  //
+  // Setup the colors array
+  vtkUnsignedCharArray * colors = vtkUnsignedCharArray::New();
+  colors->SetNumberOfComponents(3);
+  colors->SetName("Colors");
+  colors->SetNumberOfTuples(numPts);
+
+  int progressInterval = numPts/20 + 1;
+
+  double p[3];
+  double col[3];
+  double colRange[2] = { 0.0, 1.0 };
+  int abort = 0;
+  for (int i=0; i<numPts && !abort; i++)
+  {
+      if ( !(i % progressInterval) )
+      {
+          this->UpdateProgress((double)i/numPts);
+          abort = this->GetAbortExecute();
+      }
+
+      output->GetPoint(i, p);
+      for (int j=0; j<3; j++)
+      {
+          double val = ( p[j] - this->Bounds[2*j] ) / ( this->Bounds[2*j+1] - this->Bounds[2*j] );
+          vtkMath::ClampValue( &val, colRange );
+          col[j] = val * 255.0;
+      }
+
+      colors->SetTuple(i,col);
+  }
+
+  output->GetPointData()->SetScalars( colors );
+  colors->Delete();
+
+  return 1;
+}
+
+void vtkColorPolyData::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+
+  os << indent << "Bounds: (" << this->Bounds[0] << ", "
+     << this->Bounds[1] << ", " << this->Bounds[2] << " )\n";
+}

--- a/IbisPlugins/PRISMVolumeRender/vtkColorPolyData.h
+++ b/IbisPlugins/PRISMVolumeRender/vtkColorPolyData.h
@@ -1,0 +1,54 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    vtkColorPolyData.h
+
+  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+// .NAME vtkColorPolyData - Colorize points of the polydata according to coordinate
+// .SECTION Description
+
+#ifndef vtkColorPolyData_h
+#define vtkColorPolyData_h
+
+#include "vtkDataSetAlgorithm.h"
+
+class vtkColorPolyData : public vtkDataSetAlgorithm
+{
+
+public:
+
+  vtkTypeMacro(vtkColorPolyData,vtkDataSetAlgorithm);
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+  // Description:
+  // Construct with s,t range=(0,1) and automatic plane generation turned on.
+  static vtkColorPolyData *New();
+
+  // Description:
+  // Specify the bounding box inside of which RGB values vary
+  void SetBounds(const double bounds[6]);
+  void SetBounds(double xmin, double xmax, double ymin, double ymax,
+                 double zmin, double zmax);
+
+protected:
+  vtkColorPolyData();
+  ~vtkColorPolyData() {}
+
+  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *);
+
+  double Bounds[6];
+
+private:
+  vtkColorPolyData(const vtkColorPolyData&);  // Not implemented.
+  void operator=(const vtkColorPolyData&);  // Not implemented.
+};
+
+#endif

--- a/IbisPlugins/PRISMVolumeRender/vtkColoredCube.cxx
+++ b/IbisPlugins/PRISMVolumeRender/vtkColoredCube.cxx
@@ -1,0 +1,305 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    vtkColoredCube.cxx
+
+  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+#include "vtkColoredCube.h"
+
+#include "vtkTessellatedBoxSource.h"
+#include "vtkClipConvexPolyData.h"
+#include "vtkPlane.h"
+#include "vtkPlaneCollection.h"
+#include "vtkColorPolyData.h"
+#include "vtkTriangleFilter.h"
+#include "vtkPolyDataMapper.h"
+#include "vtkRenderer.h"
+#include "vtkCamera.h"
+#include "vtkMatrix4x4.h"
+#include "vtkMath.h"
+#include "vtkObjectFactory.h"  // for vtkStandardNewMacro
+#include "vtkNew.h"
+#include "vtkUnsignedIntArray.h"
+#include "vtkPointData.h"
+#include "vtkCellArray.h"
+#include "vtkOpenGL.h"
+
+vtkStandardNewMacro(vtkColoredCube);
+
+//----------------------------------------------------------------------------
+vtkColoredCube::vtkColoredCube()
+{
+    this->Cropping = 0;
+
+    for ( int i = 0; i < 3; i++ )
+    {
+        this->Bounds[2*i]   = 0.0;
+        this->Bounds[2*i+1] = 1.0;
+        this->CroppingRegionPlanes[2*i]   = 0.0;
+        this->CroppingRegionPlanes[2*i+1] = 1.0;
+    }
+
+    BoxSource = vtkTessellatedBoxSource::New();
+
+    BoxClip = vtkClipConvexPolyData::New();
+    BoxClip->SetInputConnection( BoxSource->GetOutputPort() );
+
+    // build all clipping planes
+    AllPlanes = vtkPlaneCollection::New();
+    NearFarPlanes = vtkPlaneCollection::New();
+
+    vtkPlane * pxMin = vtkPlane::New();
+    pxMin->SetNormal( 1.0, 0.0, 0.0 );
+    AllPlanes->AddItem( pxMin );
+    pxMin->Delete();
+
+    vtkPlane * pxMax = vtkPlane::New();
+    pxMax->SetNormal( -1.0, 0.0, 0.0 );
+    AllPlanes->AddItem( pxMax );
+    pxMax->Delete();
+
+    vtkPlane * pyMin = vtkPlane::New();
+    pyMin->SetNormal( 0.0, 1.0, 0.0 );
+    AllPlanes->AddItem( pyMin );
+    pyMin->Delete();
+
+    vtkPlane * pyMax = vtkPlane::New();
+    pyMax->SetNormal( 0.0, -1.0, 0.0 );
+    AllPlanes->AddItem( pyMax );
+    pyMax->Delete();
+
+    vtkPlane * pzMin = vtkPlane::New();
+    pzMin->SetNormal( 0.0, 0.0, 1.0 );
+    AllPlanes->AddItem( pzMin );
+    pzMin->Delete();
+
+    vtkPlane * pzMax = vtkPlane::New();
+    pzMax->SetNormal( 0.0, 0.0, -1.0 );
+    AllPlanes->AddItem( pzMax );
+    pzMax->Delete();
+
+    vtkPlane * pNear = vtkPlane::New();
+    pNear->SetNormal( 1.0, 0.0, 0.0 );
+    AllPlanes->AddItem( pNear );
+    NearFarPlanes->AddItem( pNear );
+    pNear->Delete();
+
+    vtkPlane * pFar = vtkPlane::New();
+    pFar->SetNormal( 1.0, 0.0, 0.0 );
+    AllPlanes->AddItem( pFar );
+    NearFarPlanes->AddItem( pFar );
+    pFar->Delete();
+
+    BoxClip->SetPlanes( NearFarPlanes ); // Default: only clip near far
+
+    BoxColoring = vtkColorPolyData::New();
+    BoxColoring->SetInputConnection( BoxClip->GetOutputPort() );
+
+    BoxTriangles = vtkTriangleFilter::New();
+    BoxTriangles->SetInputConnection( BoxColoring->GetOutputPort() );
+
+    BoxIndices = vtkUnsignedIntArray::New();
+    BoxIndices->SetNumberOfComponents(3);
+}
+
+//----------------------------------------------------------------------------
+vtkColoredCube::~vtkColoredCube()
+{
+    BoxSource->Delete();
+    BoxClip->Delete();
+    BoxColoring->Delete();
+    BoxTriangles->Delete();
+    BoxIndices->Delete();
+    AllPlanes->Delete();
+    NearFarPlanes->Delete();
+}
+
+GLenum vtkDataTypeToGlEnum( int vtkDataType )
+{
+    GLenum res = GL_FLOAT;
+    switch( vtkDataType )
+    {
+    case VTK_CHAR:
+        res = GL_BYTE;
+        break;
+    case VTK_SIGNED_CHAR:
+        res = GL_BYTE;
+        break;
+    case VTK_UNSIGNED_CHAR:
+        res = GL_UNSIGNED_BYTE;
+        break;
+    case VTK_SHORT:
+        res = GL_SHORT;
+        break;
+    case VTK_UNSIGNED_SHORT:
+        res = GL_UNSIGNED_SHORT;
+        break;
+    case VTK_INT:
+        res = GL_INT;
+        break;
+    case VTK_UNSIGNED_INT:
+        res = GL_UNSIGNED_INT;
+        break;
+    case VTK_LONG:
+        res = GL_INT;
+        break;
+    case VTK_UNSIGNED_LONG:
+        res = GL_UNSIGNED_INT;
+        break;
+    case VTK_FLOAT:
+        res = GL_FLOAT;
+        break;
+    case VTK_DOUBLE:
+        res = GL_DOUBLE;
+        break;
+    }
+    return res;
+}
+
+//----------------------------------------------------------------------------
+void vtkColoredCube::Render()
+{
+  vtkPolyData * cubePoly = vtkPolyData::SafeDownCast( BoxTriangles->GetOutput() );
+
+  // Vertices
+  vtkPoints * points = cubePoly->GetPoints();
+  glEnableClientState( GL_VERTEX_ARRAY );
+  GLenum vertexType = vtkDataTypeToGlEnum( points->GetDataType() );
+  glVertexPointer( 3, vertexType, 0, points->GetData()->GetVoidPointer(0) );
+
+  // Colors
+  vtkDataArray * colors = cubePoly->GetPointData()->GetScalars();
+  glEnableClientState( GL_COLOR_ARRAY );
+  glColorPointer( 3, GL_UNSIGNED_BYTE, 0, colors->GetVoidPointer(0) );
+
+  // Draw Triangles
+  glDrawElements( GL_TRIANGLES, BoxIndices->GetDataSize(), GL_UNSIGNED_INT, BoxIndices->GetVoidPointer(0) );
+
+  // Restore previous state
+  glDisableClientState( GL_VERTEX_ARRAY );
+  glDisableClientState( GL_COLOR_ARRAY );
+}
+
+//----------------------------------------------------------------------------
+void vtkColoredCube::UpdateGeometry( vtkRenderer * ren, vtkMatrix4x4  *mat )
+{
+    BoxSource->SetBounds(this->Bounds);
+    BoxColoring->SetBounds(this->Bounds);
+
+    // Update bounds planes position
+    AllPlanes->GetItem( 0 )->SetOrigin( CroppingRegionPlanes[0], 0.0, 0.0 );
+    AllPlanes->GetItem( 1 )->SetOrigin( CroppingRegionPlanes[1], 0.0, 0.0 );
+    AllPlanes->GetItem( 2 )->SetOrigin( 0.0, CroppingRegionPlanes[2], 0.0 );
+    AllPlanes->GetItem( 3 )->SetOrigin( 0.0, CroppingRegionPlanes[3], 0.0 );
+    AllPlanes->GetItem( 4 )->SetOrigin( 0.0, 0.0, CroppingRegionPlanes[4] );
+    AllPlanes->GetItem( 5 )->SetOrigin( 0.0, 0.0, CroppingRegionPlanes[5] );
+
+    // Update near/far planes normal and position
+    vtkCamera * cam = ren->GetActiveCamera();
+    double near = cam->GetClippingRange()[0];
+    double far = cam->GetClippingRange()[1];
+
+    // Get the inverse of the volume matrix
+    vtkMatrix4x4 * invVolMatrix = vtkMatrix4x4::New();
+    invVolMatrix->DeepCopy( mat );
+    invVolMatrix->Invert();
+
+    // Transform camera position and target to volume space
+    double pos[4] = { 0.0, 0.0, 0.0, 1.0 };
+    cam->GetPosition( pos );
+    invVolMatrix->MultiplyPoint( pos, pos );
+
+    double target[4] = { 0.0, 0.0, 0.0, 1.0 };
+    cam->GetFocalPoint( target );
+    invVolMatrix->MultiplyPoint( target, target );
+
+    // Compute direction of projection
+    double dir[3] = { 1.0, 0.0, 0.0 };
+    vtkMath::Subtract( target, pos, dir );
+    vtkMath::Normalize( dir );
+
+    // Compute an offset for the near and far planes to avoid being clipped
+    // due to floating-point precision
+    // offset calculation stolen from vtkOpenGLVolumeRaycastMapper : choose arbitrary
+    // offset. if the offset is larger than the distance between near and far point,
+    // it will not work, in this case we pick a fraction of the near-far distance.
+    double distNearFar = far - near;
+    double offset = 0.001; // some arbitrary small value.
+    if( offset >= distNearFar)
+      offset = distNearFar / 1000.0;
+    near += offset;
+    far -= offset;
+
+    // Compute near plane
+    double nearOrigin[3] = { 0.0, 0.0, 0.0 };
+    double nearNormal[3] = { 1.0, 0.0, 0.0 };
+    for( int i = 0; i < 3; ++i )
+    {
+        nearOrigin[i] = pos[i] + dir[i] * near;
+        nearNormal[i] = dir[i];
+    }
+    AllPlanes->GetItem(6)->SetOrigin( nearOrigin );
+    AllPlanes->GetItem(6)->SetNormal( nearNormal );
+
+    // Compute far plane
+    double farOrigin[3] = { 0.0, 0.0, 0.0 };
+    double farNormal[3] = { 1.0, 0.0, 0.0 };
+    for( int i = 0; i < 3; ++i )
+    {
+        farOrigin[i] = pos[i] + dir[i] * far;
+        farNormal[i] = -dir[i];
+    }
+    AllPlanes->GetItem(7)->SetOrigin( farOrigin );
+    AllPlanes->GetItem(7)->SetNormal( farNormal );
+
+    BoxClip->Modified();
+
+    // Make sure polydata is up to date
+    BoxTriangles->Update();
+
+    // Convert triangle indices to unsigned int
+    vtkPolyData * cubePoly = vtkPolyData::SafeDownCast( BoxTriangles->GetOutput() );
+    vtkCellArray * cells = cubePoly->GetPolys();
+    BoxIndices->SetNumberOfTuples( 0 );
+    vtkIdType npts;
+    vtkIdType *pts;
+    cells->InitTraversal();
+    while(cells->GetNextCell(npts, pts))
+    {
+        BoxIndices->InsertNextTuple3(pts[0], pts[1], pts[2]);
+    }
+}
+
+void vtkColoredCube::SetCropping( int c )
+{
+    int clamped = c > 0 ? 1 : 0;
+    if( this->Cropping == clamped )
+        return;
+
+    this->Cropping = clamped;
+    if( this->Cropping == 0 )
+        this->BoxClip->SetPlanes( this->NearFarPlanes );
+    else
+        this->BoxClip->SetPlanes( this->AllPlanes );
+
+    this->Modified();
+}
+
+//----------------------------------------------------------------------------
+void vtkColoredCube::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+
+  os << indent << "Bounds: ( ";
+  for( int i = 0; i < 5; ++i )
+      os << this->Bounds[i] << ", ";
+  os << this->Bounds[5] << " )" << endl;
+}

--- a/IbisPlugins/PRISMVolumeRender/vtkColoredCube.h
+++ b/IbisPlugins/PRISMVolumeRender/vtkColoredCube.h
@@ -1,0 +1,70 @@
+#ifndef vtkColoredCube_h
+#define vtkColoredCube_h
+
+#include "vtkObject.h"
+
+class vtkTessellatedBoxSource;
+class vtkClipConvexPolyData;
+class vtkPlaneCollection;
+class vtkColorPolyData;
+class vtkTriangleFilter;
+class vtkUnsignedIntArray;
+class vtkPolyData;
+class vtkRenderer;
+class vtkWindow;
+class vtkMatrix4x4;
+
+class vtkColoredCube : public vtkObject
+{
+
+public:
+
+  static vtkColoredCube *New();
+  vtkTypeMacro(vtkColoredCube,vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+  void UpdateGeometry( vtkRenderer * ren, vtkMatrix4x4 * mat );
+  void Render();
+
+  // Description:
+  // Release any graphics resources that are being consumed by this actor.
+  // The parameter window could be used to determine which graphic
+  // resources to release.
+  void ReleaseGraphicsResources(vtkWindow *);
+
+  // Description:
+  // Specify the bounding box and cropping region
+  vtkGetVector6Macro( Bounds, double );
+  vtkSetVector6Macro( Bounds, double );
+  vtkGetVector6Macro( CroppingRegionPlanes, double );
+  vtkSetVector6Macro( CroppingRegionPlanes, double );
+
+  void SetCropping( int c );
+  vtkGetMacro( Cropping, int );
+  vtkBooleanMacro( Cropping, int );
+
+protected:
+
+  vtkColoredCube();
+  ~vtkColoredCube();
+
+  // Drawing the bounding box
+  int Cropping;
+  double Bounds[6];
+  double CroppingRegionPlanes[6];
+  vtkTessellatedBoxSource * BoxSource;
+  vtkClipConvexPolyData * BoxClip;
+  vtkColorPolyData * BoxColoring;
+  vtkTriangleFilter * BoxTriangles;
+  vtkUnsignedIntArray * BoxIndices;
+  vtkPlaneCollection * AllPlanes;
+  vtkPlaneCollection * NearFarPlanes;
+
+private:
+
+  vtkColoredCube(const vtkColoredCube&);  // Not implemented.
+  void operator=(const vtkColoredCube&);  // Not implemented.
+};
+
+#endif
+

--- a/IbisPlugins/PRISMVolumeRender/vtkPRISMVolumeMapper.h
+++ b/IbisPlugins/PRISMVolumeRender/vtkPRISMVolumeMapper.h
@@ -34,6 +34,7 @@ class vtkVolumeProperty;
 class vtkRenderWindow;
 class DrawableTexture;
 class GlslShader;
+class vtkColoredCube;
 
 class vtkIbisRenderState
 {
@@ -133,13 +134,13 @@ protected:
 
   // Graphics resources
   DrawableTexture * BackfaceTexture;
-  DrawableTexture * ClippingMask;
   GlslShader * VolumeShader;
   GlslShader * BackfaceShader;
   bool VolumeShaderNeedsUpdate;
   unsigned DepthBufferTextureId;
   int DepthBufferTextureSize[2];
   vtkMatrix4x4 * WorldToTextureMatrix;
+  vtkColoredCube * ColoredCube;
 
   // Extension management
   bool GlExtensionsLoaded;
@@ -148,7 +149,6 @@ protected:
 
   bool CreateBackfaceShader();
   bool UpdateVolumeShader();
-  bool RenderClippingMask( int width, int height );
 
   // update the matrix that transforms from world coordinate to GL texture coordinates
   void UpdateWorldToTextureMatrix( vtkVolume * volume );
@@ -183,9 +183,6 @@ protected:
   // Impemented in subclass - check is texture size is OK.
   virtual int IsTextureSizeSupported( int size[3] );
 
-  void DrawCube();
-  void DrawCubeNoColor();
-  void RenderClippingPlane( vtkRenderer * ren );
   void LoadExtensions( vtkRenderWindow * window );
   void GetRenderSize( vtkRenderer * ren, int size[2] );
 

--- a/IbisPlugins/PRISMVolumeRender/vtkPRISMVolumeRaycast_FS.glsl
+++ b/IbisPlugins/PRISMVolumeRender/vtkPRISMVolumeRaycast_FS.glsl
@@ -2,8 +2,6 @@
 
 uniform sampler2DRect back_tex_id;
 uniform sampler2DRect depthBuffer;
-uniform sampler2DRect clippingMask;
-uniform int useClipping;
 uniform float time;
 uniform sampler3D volumes[@NumberOfVolumes@];
 uniform sampler1D transferFunctions[@NumberOfVolumes@];
@@ -131,16 +129,6 @@ vec3 hsv2rgb(vec3 c)
 
 void main()
 {
-    // When rendering clipped part of the cube, discard every section that is not in the mask
-    if( useClipping == 1 )
-    {
-        vec4 clipMaskSample = texture2DRect( clippingMask, gl_FragCoord.xy );
-        if( clipMaskSample.x < 0.1 )
-        {
-            discard;
-        }
-    }
-
     // Basic depth test : if something is in front of the front cube, just give up now
     vec4 depthSample = texture2DRect( depthBuffer, gl_FragCoord.xy );
     if( depthSample.x < gl_FragCoord.z )


### PR DESCRIPTION
Changed clipping strategy for near and far planes from the render-pass based to clipping of supporting geometry. It removes artefacts at the boundary between clipped and unclipped regions that was caused by the offset between the real clipping plane and the rendered plane. Also: added 6 orthogonal clipping planes supported by other vtk volume mappers.