### PR TITLE
VTK volume rendering in ImageObject: Use only vtkGPUVolumeRaycastMapper

### DIFF
--- a/IbisLib/gui/imageobjectvolumesettingswidget.cpp
+++ b/IbisLib/gui/imageobjectvolumesettingswidget.cpp
@@ -35,8 +35,6 @@ void ImageObjectVolumeSettingsWidget::SetImageObject( ImageObject * img )
     vtkVolumeProperty * prop = m_imageObject->GetVolumeProperty();
     ui->scalarOpacityFunctionWidget->SetFunction( prop->GetScalarOpacity() );
     ui->scalarOpacityFunctionWidget->SetYRange( 0.0, 1.0 );
-    ui->gradientOpacityFunctionWidget->SetFunction( prop->GetGradientOpacity() );
-    ui->gradientOpacityFunctionWidget->SetYRange( 0.0, 1.0 );
     ui->colorFunctionWidget->SetColorTransferFunction( prop->GetRGBTransferFunction() );
     ui->colorFunctionWidget->SetXRange( 0.0, 255.0 );
 
@@ -54,19 +52,6 @@ void ImageObjectVolumeSettingsWidget::UpdateUi()
     ui->showClippingWidgetCheckBox->blockSignals( true );
     ui->showClippingWidgetCheckBox->setChecked( m_imageObject->IsShowingVolumeClippingWidget() );
     ui->showClippingWidgetCheckBox->blockSignals( false );
-
-    ui->renderModeComboBox->blockSignals( true );
-    ui->renderModeComboBox->clear();
-    ui->renderModeComboBox->addItem( "GPU Raycast", QVariant( (int)vtkSmartVolumeMapper::GPURenderMode ) );
-    if( m_imageObject->GetVtkVolumeRenderMode() == (int)vtkSmartVolumeMapper::GPURenderMode )
-        ui->renderModeComboBox->setCurrentIndex( 0 );
-    ui->renderModeComboBox->addItem( "3D Texture", QVariant( (int)vtkSmartVolumeMapper::TextureRenderMode ) );
-    if( m_imageObject->GetVtkVolumeRenderMode() == (int)vtkSmartVolumeMapper::TextureRenderMode )
-        ui->renderModeComboBox->setCurrentIndex( 1 );
-    ui->renderModeComboBox->addItem( "3D Texture + Raycast", QVariant( (int)vtkSmartVolumeMapper::RayCastAndTextureRenderMode ) );
-    if( m_imageObject->GetVtkVolumeRenderMode() == (int)vtkSmartVolumeMapper::RayCastAndTextureRenderMode )
-        ui->renderModeComboBox->setCurrentIndex( 2 );
-    ui->renderModeComboBox->blockSignals( false );
 
     ui->levelSpinBox->blockSignals( true );
     ui->levelSpinBox->setValue( m_imageObject->GetVolumeRenderingLevel() );
@@ -104,34 +89,7 @@ void ImageObjectVolumeSettingsWidget::UpdateUi()
 
     ui->specularPowerSpinBox->blockSignals( true );
     ui->specularPowerSpinBox->setValue( prop->GetSpecularPower() );
-    ui->specularPowerSpinBox->blockSignals( false );
-
-    ui->gradientOpacityCheckBox->blockSignals( true );
-    ui->gradientOpacityCheckBox->setChecked( prop->GetDisableGradientOpacity() == 1 ? false : true );
-    ui->gradientOpacityCheckBox->blockSignals( false );
-
-    // Hide control that are useless in certain render mode
-    if( m_imageObject->GetVtkVolumeRenderMode() == (int)vtkSmartVolumeMapper::GPURenderMode )
-    {
-        ui->windowLevelFrame->setHidden( false );
-        ui->shadingParamsFrame->setHidden( true );
-        ui->gradientOpacityCheckBox->setHidden( true );
-        ui->gradientOpacityFunctionWidget->setHidden( true );
-    }
-    else if( m_imageObject->GetVtkVolumeRenderMode() == (int)vtkSmartVolumeMapper::TextureRenderMode )
-    {
-        ui->windowLevelFrame->setHidden( true );
-        ui->shadingParamsFrame->setHidden( false );
-        ui->gradientOpacityCheckBox->setHidden( false );
-        ui->gradientOpacityFunctionWidget->setHidden( false );
-    }
-    else if( m_imageObject->GetVtkVolumeRenderMode() == (int)vtkSmartVolumeMapper::RayCastAndTextureRenderMode )
-    {
-        ui->windowLevelFrame->setHidden( true );
-        ui->shadingParamsFrame->setHidden( false );
-        ui->gradientOpacityCheckBox->setHidden( false );
-        ui->gradientOpacityFunctionWidget->setHidden( false );
-    }
+    ui->specularPowerSpinBox->blockSignals( false );   
 }
 
 void ImageObjectVolumeSettingsWidget::on_enableVolumeRenderingCheckBox_toggled( bool checked )
@@ -174,14 +132,6 @@ void ImageObjectVolumeSettingsWidget::on_gradientOpacityCheckBox_toggled(bool ch
 {
     Q_ASSERT( m_imageObject );
     m_imageObject->GetVolumeProperty()->SetDisableGradientOpacity( checked ? 0 : 1 );
-}
-
-void ImageObjectVolumeSettingsWidget::on_renderModeComboBox_currentIndexChanged( int index )
-{
-    Q_ASSERT( m_imageObject );
-    int renderMode = ui->renderModeComboBox->itemData( index ).toInt();
-    m_imageObject->SetVtkVolumeRenderMode( renderMode );
-    UpdateUi();
 }
 
 void ImageObjectVolumeSettingsWidget::on_levelSpinBox_valueChanged( double val )

--- a/IbisLib/gui/imageobjectvolumesettingswidget.h
+++ b/IbisLib/gui/imageobjectvolumesettingswidget.h
@@ -39,14 +39,10 @@ private slots:
     void on_specularSpinBox_valueChanged(double arg1);
     void on_specularPowerSpinBox_valueChanged(double arg1);
     void on_gradientOpacityCheckBox_toggled(bool checked);
-    void on_renderModeComboBox_currentIndexChanged(int index);
     void on_levelSpinBox_valueChanged(double arg1);
     void on_windowSpinBox_valueChanged(double arg1);
-
     void on_autoSampleDistanceCheckBox_toggled(bool checked);
-
     void on_sampleDistanceSpinBox_valueChanged(double arg1);
-
     void on_showClippingWidgetCheckBox_toggled(bool checked);
 
 private:

--- a/IbisLib/gui/imageobjectvolumesettingswidget.ui
+++ b/IbisLib/gui/imageobjectvolumesettingswidget.ui
@@ -29,33 +29,6 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QLabel" name="renderModeLabel">
-       <property name="text">
-        <string>Render Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="renderModeComboBox"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
     <widget class="QCheckBox" name="shadingCheckBox">
      <property name="text">
       <string>Enable Shading</string>
@@ -345,20 +318,6 @@
     <widget class="vtkQtPiecewiseFunctionWidget" name="scalarOpacityFunctionWidget" native="true">
      <property name="toolTip">
       <string>Scalar Opacity Transfer Function</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="gradientOpacityCheckBox">
-     <property name="text">
-      <string>Enable Gradient Opacity</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="vtkQtPiecewiseFunctionWidget" name="gradientOpacityFunctionWidget" native="true">
-     <property name="toolTip">
-      <string>Gradient Opacity Transfer Function</string>
      </property>
     </widget>
    </item>

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -533,6 +533,9 @@ void ImageObject::UpdateVolumeRenderingParamsInMapper()
         if( v->GetType() == THREED_VIEW_TYPE )
         {
             PerViewElements * pv = (*it).second;
+
+            pv->volume->SetVisibility( !IsHidden() && m_vtkVolumeRenderingEnabled ? 1 : 0 );
+
             vtkGPUVolumeRayCastMapper * mapper = vtkGPUVolumeRayCastMapper::SafeDownCast( pv->volume->GetMapper() );
             Q_ASSERT( mapper );
 

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -124,8 +124,6 @@ public:
     void SetVtkVolumeRenderingEnabled( bool on );
     bool GetVtkVolumeRenderingEnabled() { return m_vtkVolumeRenderingEnabled; }
     vtkVolumeProperty * GetVolumeProperty() { return m_volumeProperty; }
-    void SetVtkVolumeRenderMode( int mode );
-    int GetVtkVolumeRenderMode() { return m_vtkVolumeRenderMode; }
     void SetVolumeRenderingWindow( double window );
     double GetVolumeRenderingWindow() { return m_colorWindow; }
     void SetVolumeRenderingLevel( double level );
@@ -196,7 +194,6 @@ protected:
     vtkEventQtSlotConnect * m_volumePropertyWatcher;
     double m_colorWindow;
     double m_colorLevel;
-    int m_vtkVolumeRenderMode;
     bool m_autoSampleDistance;
     double m_sampleDistance;
 

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -493,6 +493,12 @@ QWidget * SceneManager::CreateTrackedToolsStatusWidget( QWidget * parent )
     return res;
 }
 
+View * SceneManager::GetViewByIndex( int index )
+{
+    Q_ASSERT( index < this->Views.size() && index >= 0 );
+    return this->Views[index];
+}
+
 View * SceneManager::CreateView( int type, QString name )
 {
     View * res = this->GetView( type );

--- a/IbisLib/scenemanager.h
+++ b/IbisLib/scenemanager.h
@@ -91,6 +91,8 @@ public:
     // is no view of this type. GetOrCreateView() will return
     // a view of type 'type' if there is one, otherwise, it
     // will create one.
+    int GetNumberOfViews() { return this->Views.size(); }
+    View * GetViewByIndex( int index );
     View * CreateView( int type, QString name = QString::null );
     View * GetView( int type );
     View * GetMain3DView();

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -191,6 +191,11 @@ void View::SetQtRenderWindow( vtkQtRenderWindow * w )
     this->RenderWindow = w;
 }
 
+void View::Render()
+{
+    this->Interactor->Render();
+}
+
 void View::SetRenderingEnabled( bool b )
 {
     if( m_renderingEnabled == b )

--- a/IbisLib/view.h
+++ b/IbisLib/view.h
@@ -73,6 +73,7 @@ public:
     void SetQtRenderWindow( vtkQtRenderWindow * w );
 
     // Control rendering of the view
+    void Render();
     void SetRenderingEnabled( bool b );
     
     vtkGetObjectMacro(Interactor,vtkRenderWindowInteractor);

--- a/IbisPlugins/FrameRateTester/CMakeLists.txt
+++ b/IbisPlugins/FrameRateTester/CMakeLists.txt
@@ -1,0 +1,9 @@
+project( ${PluginName} )
+
+# define sources
+set( PluginSrc frameratetesterplugininterface.cpp frameratetesterwidget.cpp )
+set( PluginHdrMoc frameratetesterwidget.h frameratetesterplugininterface.h )
+set( PluginUi frameratetesterwidget.ui )
+
+# Create plugin
+DefinePlugin( "${PluginSrc}" "${PluginHdr}" "${PluginHdrMoc}" "${PluginUi}" )

--- a/IbisPlugins/FrameRateTester/declare-plugin.cmake
+++ b/IbisPlugins/FrameRateTester/declare-plugin.cmake
@@ -1,0 +1,1 @@
+DeclarePlugin( FrameRateTester NO DESCRIPTION “This plugin is used to test the maximum frame rate achieved in one of the graphics window of IBIS.” )

--- a/IbisPlugins/FrameRateTester/frameratetesterplugininterface.cpp
+++ b/IbisPlugins/FrameRateTester/frameratetesterplugininterface.cpp
@@ -1,0 +1,137 @@
+/*=========================================================================
+Ibis Neuronav
+Copyright (c) Simon Drouin, Anna Kochanowska, Louis Collins.
+All rights reserved.
+See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+// Thanks to Simon Drouin for writing this class
+
+#include "frameratetesterplugininterface.h"
+#include "frameratetesterwidget.h"
+//#include <QtPlugin>
+//#include "vtkEventQtSlotConnect.h"
+//#include "vtkRenderer.h"
+#include "application.h"
+#include "scenemanager.h"
+#include "view.h"
+#include <QTimer>
+#include <QTime>
+
+FrameRateTesterPluginInterface::FrameRateTesterPluginInterface()
+{
+    m_period = 10;
+    m_timer = 0;
+    m_lastNumberOfFrames = 0;
+    m_lastPeriod = 0.0;
+    m_currentViewIndex = 3;
+    m_time = new QTime;
+    m_accumulatedFrames = 0;
+}
+
+FrameRateTesterPluginInterface::~FrameRateTesterPluginInterface()
+{
+}
+
+bool FrameRateTesterPluginInterface::CanRun()
+{
+    return true;
+}
+
+QWidget * FrameRateTesterPluginInterface::CreateTab()
+{
+    FrameRateTesterWidget * widget = new FrameRateTesterWidget;
+    widget->SetPluginInterface( this );
+
+    return widget;
+}
+
+bool FrameRateTesterPluginInterface::WidgetAboutToClose()
+{
+    return true;
+}
+
+void FrameRateTesterPluginInterface::SetRunning( bool run )
+{
+    Q_ASSERT( run != IsRunning() );
+    if( run )
+    {
+        // init frame rate vars
+        m_lastNumberOfFrames = 0;
+        m_lastPeriod = 0.0;
+        m_accumulatedFrames = 0;
+
+        // Make sure other views are not rendering
+        SetRenderingEnabled( false );
+
+        // Init time measure
+        m_time->restart();
+
+        // Start a timer
+        m_timer = new QTimer;
+        connect( m_timer, SIGNAL(timeout()), this, SLOT(OnTimerTriggered()) );
+        m_timer->start(0);
+    }
+    else
+    {
+        // Kill timer
+        m_timer->stop();
+        delete m_timer;
+        m_timer = 0;
+
+        // Reenable rendering everywhere
+        SetRenderingEnabled( true );
+    }
+}
+
+bool FrameRateTesterPluginInterface::IsRunning()
+{
+    return m_timer != 0;
+}
+
+void FrameRateTesterPluginInterface::SetPeriod( int nbSeconds )
+{
+    m_period = nbSeconds;
+}
+
+double FrameRateTesterPluginInterface::GetLastFrameRate()
+{
+    if( m_lastPeriod > 0.0 )
+        return m_lastNumberOfFrames / m_lastPeriod;
+    return 0.0;
+}
+
+void FrameRateTesterPluginInterface::SetCurrentViewIndex( int index )
+{
+    Q_ASSERT( index < GetSceneManager()->GetNumberOfViews() && index >= 0 );
+    m_currentViewIndex = index;
+}
+
+void FrameRateTesterPluginInterface::OnTimerTriggered()
+{
+    // Render
+    GetSceneManager()->GetViewByIndex( m_currentViewIndex )->Render();
+
+    // Increment stats
+    m_lastPeriod = ((double)m_time->elapsed()) * 0.001;
+    m_lastNumberOfFrames++;
+    m_accumulatedFrames++;
+    if( m_accumulatedFrames > 20 )
+    {
+        m_accumulatedFrames = 0;
+        emit PeriodicSignal();
+    }
+}
+
+void FrameRateTesterPluginInterface::SetRenderingEnabled( bool enabled )
+{
+    int nbViews = GetSceneManager()->GetNumberOfViews();
+    for( int i = 0; i < nbViews; ++i )
+    {
+        if( i != m_currentViewIndex )
+            GetSceneManager()->GetViewByIndex( i )->SetRenderingEnabled( enabled );
+    }
+}

--- a/IbisPlugins/FrameRateTester/frameratetesterplugininterface.h
+++ b/IbisPlugins/FrameRateTester/frameratetesterplugininterface.h
@@ -41,8 +41,8 @@ public:
     void SetRunning( bool run );
     bool IsRunning();
 
-    void SetPeriod( int nbSeconds );
-    int GetPeriod() { return m_period; }
+    void SetNumberOfFrames( int nb );
+    int GetNumberOfFrames() { return m_numberOfFrames; }
 
     int GetLastNumberOfFrames() { return m_lastNumberOfFrames; }
     double GetLastPeriod() { return m_lastPeriod; }
@@ -64,7 +64,7 @@ protected:
 
     void SetRenderingEnabled( bool enabled );
 
-    int m_period;
+    int m_numberOfFrames;
     QTimer * m_timer;
     QTime * m_time;
 

--- a/IbisPlugins/FrameRateTester/frameratetesterplugininterface.h
+++ b/IbisPlugins/FrameRateTester/frameratetesterplugininterface.h
@@ -1,0 +1,80 @@
+/*=========================================================================
+Ibis Neuronav
+Copyright (c) Simon Drouin, Anna Kochanowska, Louis Collins.
+All rights reserved.
+See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+// Thanks to Simon Drouin for writing this class
+
+#ifndef __FrameRateTesterPluginInterface_h_
+#define __FrameRateTesterPluginInterface_h_
+
+#include <QObject>
+#include "toolplugininterface.h"
+
+//class vtkEventQtSlotConnect;
+class QTimer;
+class QTime;
+
+class FrameRateTesterPluginInterface : public QObject, public ToolPluginInterface
+{
+
+    Q_OBJECT
+    Q_INTERFACES(IbisPlugin)
+    Q_PLUGIN_METADATA(IID "Ibis.FrameRateTesterPluginInterface" )
+
+public:
+
+    FrameRateTesterPluginInterface();
+    virtual ~FrameRateTesterPluginInterface();
+    virtual QString GetPluginName() { return QString("FrameRateTester"); }
+    virtual bool CanRun();
+    virtual QString GetMenuEntryString() { return QString("Test Frame Rate"); }
+
+    virtual QWidget * CreateTab();
+    virtual bool WidgetAboutToClose();
+
+    void SetRunning( bool run );
+    bool IsRunning();
+
+    void SetPeriod( int nbSeconds );
+    int GetPeriod() { return m_period; }
+
+    int GetLastNumberOfFrames() { return m_lastNumberOfFrames; }
+    double GetLastPeriod() { return m_lastPeriod; }
+    double GetLastFrameRate();
+
+    void SetCurrentViewIndex( int index );
+    int GetCurrentViewIndex() { return m_currentViewIndex; }
+
+private slots:
+
+    void OnTimerTriggered();
+
+signals:
+
+    void Modified();
+    void PeriodicSignal();
+
+protected:
+
+    void SetRenderingEnabled( bool enabled );
+
+    int m_period;
+    QTimer * m_timer;
+    QTime * m_time;
+
+    int m_lastNumberOfFrames;
+    double m_lastPeriod;
+    int m_currentViewIndex;
+
+    // temp var used when running
+    int m_accumulatedFrames;
+
+};
+
+#endif

--- a/IbisPlugins/FrameRateTester/frameratetesterwidget.cpp
+++ b/IbisPlugins/FrameRateTester/frameratetesterwidget.cpp
@@ -1,0 +1,98 @@
+/*=========================================================================
+Ibis Neuronav
+Copyright (c) Simon Drouin, Anna Kochanowska, Louis Collins.
+All rights reserved.
+See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+// Thanks to Simon Drouin for writing this class
+
+#include "frameratetesterwidget.h"
+#include "ui_frameratetesterwidget.h"
+#include "frameratetesterplugininterface.h"
+#include "scenemanager.h"
+#include "vtkqtrenderwindow.h"
+#include <QSize>
+
+FrameRateTesterWidget::FrameRateTesterWidget(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::FrameRateTesterWidget)
+{
+    ui->setupUi(this);
+}
+
+FrameRateTesterWidget::~FrameRateTesterWidget()
+{
+    delete ui;
+}
+
+void FrameRateTesterWidget::SetPluginInterface( FrameRateTesterPluginInterface * pi )
+{
+    m_pluginInterface = pi;
+    connect( m_pluginInterface, SIGNAL(PeriodicSignal()), this, SLOT(UpdateStats()) );
+    connect( m_pluginInterface, SIGNAL(Modified()), this, SLOT(UpdateUi()) );
+    UpdateUi();
+}
+
+void FrameRateTesterWidget::UpdateUi()
+{
+    Q_ASSERT( m_pluginInterface );
+
+    // Current view combo
+    ui->currentViewComboBox->blockSignals( true );
+    ui->currentViewComboBox->clear();
+    int nbViews = m_pluginInterface->GetSceneManager()->GetNumberOfViews();
+    for( int i = 0; i < nbViews; ++i )
+    {
+        View * v = m_pluginInterface->GetSceneManager()->GetViewByIndex( i );
+        ui->currentViewComboBox->addItem( v->GetName() );
+    }
+    ui->currentViewComboBox->setCurrentIndex( m_pluginInterface->GetCurrentViewIndex() );
+    ui->currentViewComboBox->blockSignals( false );
+
+    // View size
+    View * v = m_pluginInterface->GetSceneManager()->GetViewByIndex( m_pluginInterface->GetCurrentViewIndex() );
+    QSize s = v->GetQtRenderWindow()->size();
+    ui->windowSizeLabel->setText( QString("Size : %1 x %2").arg( s.width() ).arg( s.height() ) );
+
+    // Run button
+    ui->runButton->blockSignals( true );
+    ui->runButton->setChecked( m_pluginInterface->IsRunning() );
+    ui->runButton->blockSignals( false );
+
+    // Period
+    ui->periodSpinBox->blockSignals( true );
+    ui->periodSpinBox->setValue( m_pluginInterface->GetPeriod() );
+    ui->periodSpinBox->blockSignals( false );
+
+    UpdateStats();
+
+}
+
+void FrameRateTesterWidget::UpdateStats()
+{
+    ui->lastPeriodLabel->setText( QString("Period : %1").arg( m_pluginInterface->GetLastPeriod() ) );
+    ui->numberOfFramesLabel->setText( QString("Nb Frames : %1").arg( m_pluginInterface->GetLastNumberOfFrames() ) );
+    ui->frameRateLabel->setText( QString("Fps : %1").arg( m_pluginInterface->GetLastFrameRate() ) );
+}
+
+void FrameRateTesterWidget::on_currentViewComboBox_currentIndexChanged(int index)
+{
+    Q_ASSERT( m_pluginInterface );
+    m_pluginInterface->SetCurrentViewIndex( index );
+}
+
+void FrameRateTesterWidget::on_periodSpinBox_valueChanged(int arg1)
+{
+    Q_ASSERT( m_pluginInterface );
+    m_pluginInterface->SetPeriod( arg1 );
+}
+
+void FrameRateTesterWidget::on_runButton_toggled(bool checked)
+{
+    Q_ASSERT( m_pluginInterface );
+    m_pluginInterface->SetRunning( checked );
+}

--- a/IbisPlugins/FrameRateTester/frameratetesterwidget.cpp
+++ b/IbisPlugins/FrameRateTester/frameratetesterwidget.cpp
@@ -61,11 +61,12 @@ void FrameRateTesterWidget::UpdateUi()
     // Run button
     ui->runButton->blockSignals( true );
     ui->runButton->setChecked( m_pluginInterface->IsRunning() );
+    ui->runButton->setText(  m_pluginInterface->IsRunning() ? "Stop" : "Run" );
     ui->runButton->blockSignals( false );
 
     // Period
     ui->periodSpinBox->blockSignals( true );
-    ui->periodSpinBox->setValue( m_pluginInterface->GetPeriod() );
+    ui->periodSpinBox->setValue( m_pluginInterface->GetNumberOfFrames() );
     ui->periodSpinBox->blockSignals( false );
 
     UpdateStats();
@@ -88,7 +89,7 @@ void FrameRateTesterWidget::on_currentViewComboBox_currentIndexChanged(int index
 void FrameRateTesterWidget::on_periodSpinBox_valueChanged(int arg1)
 {
     Q_ASSERT( m_pluginInterface );
-    m_pluginInterface->SetPeriod( arg1 );
+    m_pluginInterface->SetNumberOfFrames( arg1 );
 }
 
 void FrameRateTesterWidget::on_runButton_toggled(bool checked)

--- a/IbisPlugins/FrameRateTester/frameratetesterwidget.h
+++ b/IbisPlugins/FrameRateTester/frameratetesterwidget.h
@@ -1,0 +1,55 @@
+/*=========================================================================
+Ibis Neuronav
+Copyright (c) Simon Drouin, Anna Kochanowska, Louis Collins.
+All rights reserved.
+See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+// Thanks to Simon Drouin for writing this class
+
+#ifndef __FrameRateTesterWidget_h_
+#define __FrameRateTesterWidget_h_
+
+#include <QWidget>
+
+class Application;
+class FrameRateTesterPluginInterface;
+
+namespace Ui
+{
+    class FrameRateTesterWidget;
+}
+
+
+class FrameRateTesterWidget : public QWidget
+{
+
+    Q_OBJECT
+
+public:
+
+    explicit FrameRateTesterWidget(QWidget *parent = 0);
+    ~FrameRateTesterWidget();
+
+    void SetPluginInterface( FrameRateTesterPluginInterface * pi );
+
+private slots:
+
+    void UpdateUi();
+    void UpdateStats();
+
+    void on_currentViewComboBox_currentIndexChanged(int index);
+    void on_periodSpinBox_valueChanged(int arg1);
+    void on_runButton_toggled(bool checked);
+
+private:
+
+    FrameRateTesterPluginInterface * m_pluginInterface;
+    Ui::FrameRateTesterWidget * ui;
+
+};
+
+#endif

--- a/IbisPlugins/FrameRateTester/frameratetesterwidget.ui
+++ b/IbisPlugins/FrameRateTester/frameratetesterwidget.ui
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FrameRateTesterWidget</class>
+ <widget class="QWidget" name="FrameRateTesterWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>251</width>
+    <height>527</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Current View</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QComboBox" name="currentViewComboBox"/>
+      </item>
+      <item>
+       <widget class="QLabel" name="windowSizeLabel">
+        <property name="text">
+         <string>Size:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="periodLabel">
+       <property name="text">
+        <string>Period:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="periodSpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="maximum">
+        <number>1000</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>15</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="runButton">
+       <property name="text">
+        <string>Run</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>15</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="lastTestGroupBox">
+     <property name="title">
+      <string>Last Test</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="lastPeriodLabel">
+        <property name="text">
+         <string>Period: </string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="numberOfFramesLabel">
+        <property name="text">
+         <string>Number of Frames: </string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="frameRateLabel">
+        <property name="text">
+         <string>Frame Rate: </string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/IbisPlugins/FrameRateTester/frameratetesterwidget.ui
+++ b/IbisPlugins/FrameRateTester/frameratetesterwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>251</width>
+    <width>276</width>
     <height>527</height>
    </rect>
   </property>
@@ -37,8 +37,14 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="periodLabel">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Period:</string>
+        <string>Number of frames:</string>
        </property>
       </widget>
      </item>
@@ -54,7 +60,10 @@
         <bool>false</bool>
        </property>
        <property name="maximum">
-        <number>1000</number>
+        <number>10000</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Dropped support for VTK volume rendering mode other than vtkGPUVolumeRayCastMapper. Support for other mappers was poorly implemented and vtk didn't support switching between mode properly. We use direcly vtkGPUVolumeRayCastMapper now instead of vtkSmartVolumeMapper. 

Also: fixed controls for sample distance which wasn't updated properly.

Also: ImageObject: Fixed show and hide to deal properly with vtk volume rendering.
