### PR TITLE
Fixed Animate plugin. 

### DIFF
--- a/IbisLib/mainwindow.cpp
+++ b/IbisLib/mainwindow.cpp
@@ -209,16 +209,16 @@ MainWindow::MainWindow( QWidget * parent )
     m_rightPanelSize = settings->MainWindowRightPanelSize;
     Application::GetSceneManager()->UpdateBackgroundColor();
 
-    // -----------------------------------------
-    // Create UI elements from the plugins
-    // -----------------------------------------
-    CreatePluginsUi();
-
     UpdateMainSplitter();
     Application::GetInstance().SetMainWindow(this);
 
     m_4Views->SetCurrentViewWindow( settings->CurrentViewWindow );
     m_4Views->SetExpandedView( settings->ExpandedView );
+
+    // -----------------------------------------
+    // Create UI elements from the plugins
+    // -----------------------------------------
+    CreatePluginsUi();
 
     // Tell the qApp unique instance to send event to MainWindow::eventFilter before anyone else
     // so that we can grab global keyboard shortcuts.

--- a/IbisPlugins/Animate/animateplugininterface.cpp
+++ b/IbisPlugins/Animate/animateplugininterface.cpp
@@ -417,16 +417,6 @@ void AnimatePluginInterface::SetPlaying( bool p )
         m_playbackTimer->stop();
 }
 
-#include "quadviewwindow.h"
-
-void AnimatePluginInterface::ToggleDetachWindow( bool checked )
-{
-    if( checked )
-        GetApplication()->GetQuadViewWidget()->Detach3DView( GetApplication()->GetMainWindow() );
-    else
-        GetApplication()->GetQuadViewWidget()->Attach3DView();
-}
-
 //=============================
 // For now:
 // 0 - Camera anim

--- a/IbisPlugins/Animate/animateplugininterface.h
+++ b/IbisPlugins/Animate/animateplugininterface.h
@@ -102,8 +102,6 @@ public:
     bool IsPlaying();
     void SetPlaying( bool p );
 
-    void ToggleDetachWindow( bool checked );
-
     // Funcs to manipulate keyframes
     bool HasKey( int paramIndex, int frame );
     int FindClosestKey( int paramIndex, int frame );

--- a/IbisPlugins/Animate/animatewidget.cpp
+++ b/IbisPlugins/Animate/animatewidget.cpp
@@ -221,12 +221,6 @@ void AnimateWidget::on_prevKeyframeButton_clicked()
     m_pluginInterface->PrevKeyframe();
 }
 
-void AnimateWidget::on_detachWindowButton_toggled(bool checked)
-{
-    Q_ASSERT( m_pluginInterface );
-    m_pluginInterface->ToggleDetachWindow( checked );
-}
-
 void AnimateWidget::on_domeViewAngleSlider_valueChanged(int value)
 {
     Q_ASSERT( m_pluginInterface );

--- a/IbisPlugins/Animate/animatewidget.h
+++ b/IbisPlugins/Animate/animatewidget.h
@@ -57,7 +57,6 @@ private slots:
     void on_cameraMinDistCheckBox_toggled(bool checked);
     void on_nextKeyframeButton_clicked();
     void on_prevKeyframeButton_clicked();
-    void on_detachWindowButton_toggled(bool checked);
     void on_domeViewAngleSlider_valueChanged(int value);
     void on_domeViewAngleSpinBox_valueChanged(int arg1);
 

--- a/IbisPlugins/Animate/animatewidget.ui
+++ b/IbisPlugins/Animate/animatewidget.ui
@@ -86,22 +86,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="detachWindowButton">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Detach Window</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
          <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Build of the Animate plugin broke with previous commit because of the removal of QuadViewWindow access functions. It is now fixed. Also: order of window initialization was likely to cause a crash for certain plugins.