### PR TITLE
PRISM gui fixes and look improvement on macOS

### DIFF
--- a/IbisLib/gui/opendatafiledialog.ui
+++ b/IbisLib/gui/opendatafiledialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>490</width>
-    <height>172</height>
+    <height>134</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -23,6 +23,9 @@
    <bool>false</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>4</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -34,6 +37,12 @@
      </item>
      <item>
       <widget class="QPushButton" name="browsePushButton">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>40</width>
@@ -48,15 +57,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QCheckBox" name="lablelImageCheckBox">
-       <property name="text">
-        <string>Label Image</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <layout class="QHBoxLayout" name="horizontalLayout_3"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -90,6 +91,13 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QCheckBox" name="lablelImageCheckBox">
+       <property name="text">
+        <string>Label Image</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -107,12 +115,6 @@
    </item>
    <item>
     <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="margin">
-      <number>0</number>
-     </property>
      <item>
       <spacer name="Horizontal Spacing2">
        <property name="orientation">

--- a/IbisPlugins/PRISMVolumeRender/volumerenderingobject.h
+++ b/IbisPlugins/PRISMVolumeRender/volumerenderingobject.h
@@ -128,8 +128,8 @@ public:
     bool DoesShaderContributionTypeExist( QString name );
     void AddShaderContributionType( QString shaderName, QString code, bool custom );
     QString GetUniqueCustomShaderName( QString name );
-    void DuplicateShaderContribType( int typeIndex );
-    void DeleteShaderContributionType( QString shaderName );
+    int DuplicateShaderContribType( int typeIndex );
+    void DeleteShaderContributionType( int typeIndex );
     void SetShaderContributionType( int volumeIndex, int typeIndex );
     void SetShaderContributionTypeByName( int volumeIndex, QString name );
     int GetShaderContributionType( int volumeIndex );

--- a/IbisPlugins/PRISMVolumeRender/volumerenderingobjectsettingswidget.ui
+++ b/IbisPlugins/PRISMVolumeRender/volumerenderingobjectsettingswidget.ui
@@ -6,14 +6,17 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>312</width>
-    <height>663</height>
+    <width>269</width>
+    <height>552</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="mainLayout">
+   <property name="spacing">
+    <number>4</number>
+   </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -78,6 +81,21 @@
       <string>Brightness</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_9">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
       <item>
        <widget class="QSlider" name="multFactorSlider">
         <property name="orientation">
@@ -110,6 +128,21 @@
       <string>Interaction points</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
@@ -214,16 +247,31 @@
       <string>Ray Init</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="spacing">
+       <number>2</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QComboBox" name="rayInitComboBox"/>
-        </item>
+        <property name="spacing">
+         <number>4</number>
+        </property>
         <item>
          <widget class="QPushButton" name="addRayInitShaderButton">
           <property name="minimumSize">
            <size>
-            <width>27</width>
+            <width>50</width>
             <height>0</height>
            </size>
           </property>
@@ -242,7 +290,7 @@
          <widget class="QPushButton" name="removeRayInitShaderButton">
           <property name="minimumSize">
            <size>
-            <width>27</width>
+            <width>50</width>
             <height>0</height>
            </size>
           </property>
@@ -256,6 +304,19 @@
            <string>-</string>
           </property>
          </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item>
          <widget class="QPushButton" name="shaderInitButton">
@@ -272,7 +333,7 @@
            </size>
           </property>
           <property name="text">
-           <string>Shader</string>
+           <string>code...</string>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -280,6 +341,9 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QComboBox" name="rayInitComboBox"/>
       </item>
      </layout>
     </widget>
@@ -290,16 +354,31 @@
       <string>Stop Condition</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
+      <property name="spacing">
+       <number>2</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="QComboBox" name="stopConditionComboBox"/>
-        </item>
+        <property name="spacing">
+         <number>4</number>
+        </property>
         <item>
          <widget class="QPushButton" name="addStopConditionShaderButton">
           <property name="minimumSize">
            <size>
-            <width>27</width>
+            <width>50</width>
             <height>0</height>
            </size>
           </property>
@@ -318,7 +397,7 @@
          <widget class="QPushButton" name="removeStopConditionShaderButton">
           <property name="minimumSize">
            <size>
-            <width>27</width>
+            <width>50</width>
             <height>0</height>
            </size>
           </property>
@@ -332,6 +411,19 @@
            <string>-</string>
           </property>
          </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item>
          <widget class="QPushButton" name="shaderStopConditionButton">
@@ -348,7 +440,7 @@
            </size>
           </property>
           <property name="text">
-           <string>Shader</string>
+           <string>code...</string>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -356,6 +448,9 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QComboBox" name="stopConditionComboBox"/>
       </item>
      </layout>
     </widget>
@@ -370,10 +465,16 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>27</width>
-         <height>27</height>
+         <height>32</height>
         </size>
        </property>
        <property name="text">
@@ -392,10 +493,16 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximumSize">
         <size>
          <width>27</width>
-         <height>27</height>
+         <height>32</height>
         </size>
        </property>
        <property name="text">

--- a/IbisPlugins/PRISMVolumeRender/volumerenderingsinglevolumesettingswidget.cpp
+++ b/IbisPlugins/PRISMVolumeRender/volumerenderingsinglevolumesettingswidget.cpp
@@ -52,6 +52,8 @@ void VolumeRenderingSingleVolumeSettingsWidget::UpdateUi()
     Q_ASSERT( m_vr );
     Q_ASSERT( m_vr->GetManager() );
 
+    ui->volumeGroupBox->setTitle( QString("Volume %1").arg( m_volumeIndex ) );
+
     ui->enableVolumeCheckBox->blockSignals( true );
     ui->volumeComboBox->blockSignals( true );
 
@@ -95,6 +97,15 @@ void VolumeRenderingSingleVolumeSettingsWidget::UpdateUi()
     ui->enableVolumeCheckBox->blockSignals( false );
     ui->volumeComboBox->blockSignals( false );
 
+    // Disable interpolation and 16 bit volume checkboxes when there is no valid volume
+    ui->use16BitsVolumeCheckBox->blockSignals( true );
+    ui->use16BitsVolumeCheckBox->setEnabled( !none );
+    ui->use16BitsVolumeCheckBox->blockSignals( false );
+
+    ui->useLinearSamplingCheckBox->blockSignals( true );
+    ui->useLinearSamplingCheckBox->setEnabled( !none );
+    ui->useLinearSamplingCheckBox->blockSignals( false );
+
     // Update shader contribution combo box
     ui->contributionTypeComboBox->blockSignals( true );
     ui->contributionTypeComboBox->clear();
@@ -104,6 +115,11 @@ void VolumeRenderingSingleVolumeSettingsWidget::UpdateUi()
     }
     ui->contributionTypeComboBox->setCurrentIndex( m_vr->GetShaderContributionType( m_volumeIndex ) );
     ui->contributionTypeComboBox->blockSignals( false );
+
+    // disable remove shader button if shader type is not custom
+    int currentShaderType = m_vr->GetShaderContributionType( m_volumeIndex );
+    bool shaderIsCustom = m_vr->IsShaderTypeCustom( currentShaderType );
+    ui->removeVolumeShaderButton->setEnabled( shaderIsCustom );
 
     // make sure we repaint transfer func widgets
     ui->colorFunctionWidget->update();
@@ -177,7 +193,15 @@ void VolumeRenderingSingleVolumeSettingsWidget::on_addShaderContribTypeButton_cl
 {
     Q_ASSERT( m_vr );
     int contribType = m_vr->GetShaderContributionType( m_volumeIndex );
-    m_vr->DuplicateShaderContribType( contribType );
-    m_vr->SetShaderContributionType( m_volumeIndex, m_vr->GetNumberOfShaderContributionTypes() - 1 );
+    int newShaderType = m_vr->DuplicateShaderContribType( contribType );
+    if( newShaderType != -1 )
+        m_vr->SetShaderContributionType( m_volumeIndex, newShaderType );
     UpdateUi();
+}
+
+void VolumeRenderingSingleVolumeSettingsWidget::on_removeVolumeShaderButton_clicked()
+{
+    Q_ASSERT( m_vr );
+    int contribType = m_vr->GetShaderContributionType( m_volumeIndex );
+    m_vr->DeleteShaderContributionType( contribType );
 }

--- a/IbisPlugins/PRISMVolumeRender/volumerenderingsinglevolumesettingswidget.h
+++ b/IbisPlugins/PRISMVolumeRender/volumerenderingsinglevolumesettingswidget.h
@@ -48,6 +48,8 @@ private slots:
     void on_useLinearSamplingCheckBox_toggled(bool checked);
     void on_addShaderContribTypeButton_clicked();
 
+    void on_removeVolumeShaderButton_clicked();
+
 private:
 
     VolumeRenderingObject * m_vr;

--- a/IbisPlugins/PRISMVolumeRender/volumerenderingsinglevolumesettingswidget.ui
+++ b/IbisPlugins/PRISMVolumeRender/volumerenderingsinglevolumesettingswidget.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>261</width>
-    <height>298</height>
+    <width>256</width>
+    <height>325</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -23,123 +23,245 @@
    <property name="rightMargin">
     <number>0</number>
    </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="enableVolumeCheckBox">
-       <property name="maximumSize">
-        <size>
-         <width>20</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="volumeComboBox">
-       <property name="minimumSize">
-        <size>
-         <width>175</width>
-         <height>0</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="shaderPushButton">
-       <property name="maximumSize">
-        <size>
-         <width>55</width>
-         <height>31</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Shader</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="contributionTypeComboBox"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="addShaderContribTypeButton">
-       <property name="maximumSize">
-        <size>
-         <width>30</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>+</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QCheckBox" name="use16BitsVolumeCheckBox">
-       <property name="text">
-        <string>16 bits volume</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="useLinearSamplingCheckBox">
-       <property name="text">
-        <string>Linear sample</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="vtkQtPiecewiseFunctionWidget" name="opacityFunctionWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QGroupBox" name="volumeGroupBox">
+     <property name="title">
+      <string>GroupBox</string>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>250</width>
-       <height>125</height>
-      </size>
+     <property name="checkable">
+      <bool>false</bool>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="vtkQtColorTransferFunctionWidget" name="colorFunctionWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>50</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>50</height>
-      </size>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="enableVolumeCheckBox">
+          <property name="minimumSize">
+           <size>
+            <width>30</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>20</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="volumeComboBox">
+          <property name="minimumSize">
+           <size>
+            <width>175</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="addShaderContribTypeButton">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>+</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="removeVolumeShaderButton">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>-</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="shaderPushButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>32</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>55</width>
+            <height>32</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>code...</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="minimumSize">
+           <size>
+            <width>70</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>70</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Shader:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="contributionTypeComboBox"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="useLinearSamplingCheckBox">
+          <property name="text">
+           <string>Linear sample</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="use16BitsVolumeCheckBox">
+          <property name="text">
+           <string>16 bits volume</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="vtkQtPiecewiseFunctionWidget" name="opacityFunctionWidget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>250</width>
+          <height>125</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="vtkQtColorTransferFunctionWidget" name="colorFunctionWidget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>50</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+     <zorder>useLinearSamplingCheckBox</zorder>
+     <zorder></zorder>
+     <zorder></zorder>
+     <zorder></zorder>
+     <zorder></zorder>
+     <zorder>colorFunctionWidget</zorder>
+     <zorder>opacityFunctionWidget</zorder>
     </widget>
    </item>
   </layout>

--- a/IbisPlugins/PRISMVolumeRender/volumeshadereditorwidget.cpp
+++ b/IbisPlugins/PRISMVolumeRender/volumeshadereditorwidget.cpp
@@ -74,7 +74,11 @@ bool VolumeShaderEditorWidget::IsShaderCustom()
 void VolumeShaderEditorWidget::DuplicateShader()
 {
     if( m_volumeIndex >= 0 )
-        m_volumeRenderer->DuplicateShaderContribType( m_volumeRenderer->GetShaderContributionType( m_volumeIndex ) );
+    {
+        int newShaderType = m_volumeRenderer->DuplicateShaderContribType( m_volumeRenderer->GetShaderContributionType( m_volumeIndex ) );
+        if( newShaderType != -1 )
+            m_volumeRenderer->SetShaderContributionType( m_volumeIndex, newShaderType );
+    }
     else if( m_volumeIndex == -1 )
         m_volumeRenderer->DuplicateRayInitShaderType();
     else


### PR DESCRIPTION
Added possibility to choose name when creating a new custom shader. Animation is now started automatically when loading a scene that was saved with animation on. Improved look and feel of the volume settings widget and file open dialog on macOS.