### PR TITLE
SceneManager: optimized GetNumberOfUserObjects and GetAllUserObjects

### DIFF
--- a/IbisLib/scenemanager.h
+++ b/IbisLib/scenemanager.h
@@ -266,7 +266,6 @@ public:
     // returns list of all the user created/added objects with their parents
     int  GetNumberOfUserObjects();
     void GetAllUserObjects(QList<SceneObject*> &);
-    void GetChildrenUserObjects( SceneObject * obj, QList<SceneObject*> & );
 
     // Description
     // returns list of all the listable, non-tracked objects with their parents

--- a/IbisLib/sceneobject.cpp
+++ b/IbisLib/sceneobject.cpp
@@ -390,6 +390,14 @@ bool SceneObject::DescendsFrom( SceneObject * obj )
     return false;
 }
 
+bool SceneObject::IsUserObject()
+{
+    bool user = !IsManagedByTracker();
+    user &= !IsManagedBySystem();
+    user &= IsListable();
+    return user;
+}
+
 int SceneObject::GetNumberOfListableChildren()
 {
     int count = 0;

--- a/IbisLib/sceneobject.h
+++ b/IbisLib/sceneobject.h
@@ -106,6 +106,8 @@ public:
     void WorldToLocal(double worldPoint[3], double localPoint[3] );
     void LocalToWorld(double localPoint[3], double worldPoint[3] );
 
+    bool IsUserObject();
+
     int GetNumberOfListableChildren();
     SceneObject * GetListableChild( int index );
     bool IsListable() { return this->ObjectListable; }


### PR DESCRIPTION
These functions now use the AllObject list instead of parsing the SceneObject tree. Also, SceneObjects now have a function to tell if they are USER objects so the code with the conditions is only in 1 place. 

Also: fixed a bug when adding object. if the object being added is not a user object, we should not reset the view if there is only 1 user object because it was already there.