### PR TITLE
Fixed all compilation warning on macOS

### DIFF
--- a/IbisLib/cameraobject.cpp
+++ b/IbisLib/cameraobject.cpp
@@ -63,6 +63,7 @@ CameraIntrinsicParams & CameraIntrinsicParams::operator=( const CameraIntrinsicP
     m_focal[1] = other.m_focal[1];
     m_distorsionK1 = other.m_distorsionK1;
     m_reprojectionError = other.m_reprojectionError;
+    return *this;
 }
 
 void CameraIntrinsicParams::Serialize( Serializer * ser )

--- a/IbisLib/pointsobject.cpp
+++ b/IbisLib/pointsobject.cpp
@@ -476,8 +476,9 @@ int PointsObject::FindPoint(vtkActor *actor, double *pos, int viewType)
         point = m_pointList.value(i);
         point->GetPosition(pointPosition);
         wt->TransformPoint( pointPosition, worldPt );
-        if( this->GetManager()->IsInPlane( (VIEWTYPES)viewType, worldPt ) &&
-            sqrt( vtkMath::Distance2BetweenPoints( worldPicked, worldPt ) < m_pointRadius2D ))
+        bool isInPlane = this->GetManager()->IsInPlane( (VIEWTYPES)viewType, worldPt );
+        bool isInRadius = sqrt( vtkMath::Distance2BetweenPoints( worldPicked, worldPt ) ) < m_pointRadius2D;
+        if( isInPlane && isInRadius )
             return i;
     }
     return InvalidPointIndex;
@@ -615,10 +616,16 @@ void PointsObject::RemovePoint(int index)
 
     // Update selected point index
     if( m_selectedPointIndex >= GetNumberOfPoints() )
+    {
         if( GetNumberOfPoints() > 0 )
+        {
             m_selectedPointIndex = GetNumberOfPoints() - 1;
+        }
         else
+        {
             m_selectedPointIndex = InvalidPointIndex;
+        }
+    }
 
     this->UpdatePoints();
     emit PointRemoved( index );

--- a/IbisLib/serializerhelper.cpp
+++ b/IbisLib/serializerhelper.cpp
@@ -86,7 +86,7 @@ bool Serialize( Serializer * serial, const char * attrName, vtkPiecewiseFunction
 
 bool Serialize( Serializer * serial, const char * attrName, Vec3 & v )
 {
-    serial->Serialize( attrName, v.Ref(), 3 );
+    return serial->Serialize( attrName, v.Ref(), 3 );
 }
 
 bool Serialize( Serializer * serial, const char * attrName, vtkMatrix4x4 * mat )

--- a/IbisLib/trackedvideobuffer.cpp
+++ b/IbisLib/trackedvideobuffer.cpp
@@ -136,6 +136,8 @@ bool TrackedVideoBuffer::Serialize( Serializer * ser, QString dataDirectory )
     if( ser->IsReader() )
         if( m_currentFrame != -1 )
             SetCurrentFrame( m_currentFrame );
+
+    return true;
 }
 
 void TrackedVideoBuffer::Export( QString dirName, QProgressDialog * progress )

--- a/IbisLib/usmask.cpp
+++ b/IbisLib/usmask.cpp
@@ -10,6 +10,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 =========================================================================*/
 #include "usmask.h"
 #include <vtkImageData.h>
+#include <cmath>
 
 ObjectSerializationMacro( USMask );
 
@@ -204,8 +205,8 @@ void USMask::BuildMask()
                 else
                 {
                     // Test 3 : between angles
-                    double angle =  atan( abs( diff[0] ) / diff[1] );
-                    if( ( diff[0] < 0.0 && angle < m_maskAngles[0] ) || diff[0] > 0.0 && angle < m_maskAngles[1] )
+                    double angle =  atan( std::abs( diff[0] ) / diff[1] );
+                    if( ( diff[0] < 0.0 && angle < m_maskAngles[0] ) || ( diff[0] > 0.0 && angle < m_maskAngles[1] ) )
                         *pix = 0;
                     else
                         *pix = 255;

--- a/IbisLib/worldobject.cpp
+++ b/IbisLib/worldobject.cpp
@@ -57,7 +57,7 @@ bool WorldObject::AxesHidden()
     return true;
 }
 
-bool WorldObject::Set3DViewFollowsReferenceVolume( bool f )
+void WorldObject::Set3DViewFollowsReferenceVolume( bool f )
 {
     Q_ASSERT( this->GetManager() );
     this->GetManager()->Set3DViewFollowingReferenceVolume( f );

--- a/IbisLib/worldobject.h
+++ b/IbisLib/worldobject.h
@@ -42,7 +42,7 @@ public:
 
     void SetAxesHidden( bool h );
     bool AxesHidden();
-    bool Set3DViewFollowsReferenceVolume( bool f );
+    void Set3DViewFollowsReferenceVolume( bool f );
     bool Is3DViewFollowingReferenceVolume();
     void SetCursorVisible( bool v );
     bool GetCursorVisible();

--- a/IbisPlugins/PRISMVolumeRender/volumerenderingsinglevolumesettingswidget.ui
+++ b/IbisPlugins/PRISMVolumeRender/volumerenderingsinglevolumesettingswidget.ui
@@ -256,10 +256,6 @@
       </item>
      </layout>
      <zorder>useLinearSamplingCheckBox</zorder>
-     <zorder></zorder>
-     <zorder></zorder>
-     <zorder></zorder>
-     <zorder></zorder>
      <zorder>colorFunctionWidget</zorder>
      <zorder>opacityFunctionWidget</zorder>
     </widget>

--- a/IbisVTK/vtkExtensions/vtkMulti3DWidget.cxx
+++ b/IbisVTK/vtkExtensions/vtkMulti3DWidget.cxx
@@ -158,7 +158,7 @@ int vtkMulti3DWidget::GetNumberOfRenderers()
 }
 
 
-vtkRenderer * vtkMulti3DWidget::GetRenderer( unsigned int index )
+vtkRenderer * vtkMulti3DWidget::GetRenderer( int index )
 {
     if( index < this->Renderers.size() && index >= 0 )
     {
@@ -168,7 +168,7 @@ vtkRenderer * vtkMulti3DWidget::GetRenderer( unsigned int index )
 }
 
 
-vtkAssembly * vtkMulti3DWidget::GetAssembly( unsigned int index )
+vtkAssembly * vtkMulti3DWidget::GetAssembly( int index )
 {
     if( index < this->Renderers.size() && index >= 0 )
     {

--- a/IbisVTK/vtkExtensions/vtkMulti3DWidget.h
+++ b/IbisVTK/vtkExtensions/vtkMulti3DWidget.h
@@ -72,8 +72,8 @@ public:
     // child of the associated Prop3D in each renderer.
 	int AddRenderer( vtkRenderer * ren, vtkAssembly * assembly = 0 );
     int GetNumberOfRenderers();
-    vtkRenderer * GetRenderer( unsigned int index );
-    vtkAssembly * GetAssembly( unsigned int index );
+    vtkRenderer * GetRenderer( int index );
+    vtkAssembly * GetAssembly( int index );
     vtkAssembly * GetAssembly( vtkRenderer * ren );
     void RemoveRenderer( vtkRenderer * ren );
 

--- a/IbisVTK/vtkMNI/vtkTagReader.cxx
+++ b/IbisVTK/vtkMNI/vtkTagReader.cxx
@@ -23,7 +23,7 @@ int vtkTagReader::GetNumberOfVolumes()
     return this->Volumes.size();
 }
 
-vtkPoints * vtkTagReader::GetVolume( unsigned int volumeIndex )
+vtkPoints * vtkTagReader::GetVolume( int volumeIndex )
 {
     if( volumeIndex >= 0 && volumeIndex < this->Volumes.size() )
     {

--- a/IbisVTK/vtkMNI/vtkTagReader.h
+++ b/IbisVTK/vtkMNI/vtkTagReader.h
@@ -39,7 +39,7 @@ public:
 
     // Get the output of the reader
     int GetNumberOfVolumes();
-    vtkPoints * GetVolume( unsigned int volumeIndex );
+    vtkPoints * GetVolume( int volumeIndex );
     std::vector<std::string> & GetPointNames() { return PointNames; }
     std::vector<std::string> & GetVolumeNames() { return VolumeNames; }
     std::vector<std::string> & GetTimeStamps() { return TimeStamps; }

--- a/IbisVTK/vtkQt/vtkQtColorTransferFunctionWidget.cpp
+++ b/IbisVTK/vtkQt/vtkQtColorTransferFunctionWidget.cpp
@@ -12,7 +12,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPen>
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 
 #include "vtkQtColorTransferFunctionWidget.h"
@@ -433,8 +433,8 @@ double vtkQtColorTransferFunctionWidget::PixelSize()
 int vtkQtColorTransferFunctionWidget::MinDistanceCursor( int mousePosition )
 {
     double mouseValue = widgetPosToSliderValue( mousePosition );
-    double minDist = abs( getMinSliderValue() - mouseValue );
-    double maxDist = abs( getMaxSliderValue() - mouseValue );
+    double minDist = std::abs( getMinSliderValue() - mouseValue );
+    double maxDist = std::abs( getMaxSliderValue() - mouseValue );
 
     if( minDist < maxDist )
         return 0;


### PR DESCRIPTION
except for one warning: returning address of local temporary object that occurs because of a problem between llvm compiler and QMap class. The problem originates from the MainWindow class. Updates from the compiler should fix it.