### PR TITLE
Automatically load tracker tool 3D models if they exist

### DIFF
--- a/IbisHardware/tracker.h
+++ b/IbisHardware/tracker.h
@@ -27,6 +27,7 @@ class vtkMatrix4x4;
 class SceneManager;
 class TrackedVideoSource;
 class IbisHardwareModule;
+class PolyDataObject;
 
 #define BR9600    9600
 #define BR14400  14400
@@ -53,6 +54,7 @@ struct ToolDescription
     QString romFileName;
     QString cachedSerialNumber;   // serial number used to recognize active tools when plugged in
     TrackedSceneObject * sceneObject;  // Object in the scene if active or holding state if inactive
+    PolyDataObject * toolModel; // tool 3D model with origin at origin of the tracker tool
 };
 
 ObjectSerializationHeaderMacro( ToolDescription );


### PR DESCRIPTION
Before each tool is added to the scene, if the folder ~/.ibis/tool-models contains a .ply file with the same name, it is loaded and used as the 3D model for the tool.