### PR TITLE
Anisotropic voxel sizes in the FiberNavigator plugin

### DIFF
--- a/IbisPlugins/FiberNavigator/fibernavigatorplugininterface.cpp
+++ b/IbisPlugins/FiberNavigator/fibernavigatorplugininterface.cpp
@@ -419,7 +419,7 @@ vtkSmartPointer<vtkTransform> FiberNavigatorPluginInterface::prepareTransformati
 
     dataTransform->Concatenate(sceneManager->GetObjectByID(m_referenceId)->GetWorldTransform());
     dataTransform->Scale(voxelSize);
-    dataTransform->Translate(volumeOrigin);
+    dataTransform->Translate(volumeOrigin[0]/voxelSize[0], volumeOrigin[1]/voxelSize[1], volumeOrigin[2]/voxelSize[2]);
 
     return dataTransform;
 }


### PR DESCRIPTION
The misalignment between the volume and the fibers came from wrong transformation.
The voxel size scaling was applied twice to the translation 