### PR TITLE
Bug fix: incorrect interaction in initial expanded view

### DIFF
--- a/Ibis/main.cpp
+++ b/Ibis/main.cpp
@@ -58,6 +58,7 @@ int main( int argc, char** argv )
     MainWindow * mw = new MainWindow( 0 );
     mw->setAttribute( Qt::WA_DeleteOnClose );
     mw->show();
+    Application::GetInstance().LoadWindowSettings();
     a.connect( &a, SIGNAL( lastWindowClosed() ), &a, SLOT( quit() ) );
     a.connect( &a, SIGNAL( aboutToQuit() ), &Application::GetInstance(), SLOT( SaveSettings() ) );
     a.installEventFilter( mw );

--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -130,6 +130,11 @@ Application::Application( )
 void Application::SetMainWindow( MainWindow * mw )
 {
     m_mainWindow = mw;
+}
+
+void Application::LoadWindowSettings()
+{
+    Q_ASSERT( m_mainWindow );
     QSettings settings( m_appOrganisation, m_appName );
     m_mainWindow->LoadSettings( settings );
 }

--- a/IbisLib/application.h
+++ b/IbisLib/application.h
@@ -88,6 +88,7 @@ public:
     static Application & GetInstance();
 
     void SetMainWindow( MainWindow * mw );
+    void LoadWindowSettings();
     MainWindow * GetMainWindow() { return m_mainWindow; }
     void AddBottomWidget( QWidget * w );
     void RemoveBottomWidget( QWidget * w );


### PR DESCRIPTION
When ibis starts in expanded view (Qt 5.6, macOS), mouse event are not generated in a certain portion of the graphic window and thus interaction doesn't work all the time. This seems to be a Qt internal problem. The fix consists in loading window settings only after the first call to show() of MainWindow. It seems that if the window is expanded only after a certain number of internal initialization from Qt (done inside the show function), the view expansion is done properly and mouse events are generated everywhere in the window.