### PR TITLE
Resolve CanRun() problem for USManualCalibration plugin

### DIFF
--- a/IbisHardware/ibishardwaremodule.cpp
+++ b/IbisHardware/ibishardwaremodule.cpp
@@ -57,11 +57,13 @@ bool IbisHardwareModule::Init()
 
     // Init tracker
     m_tracker->Initialize();
+    if( !m_tracker->IsInitialized() )
+        return false;
 
     // Init video
-    m_trackedVideoSource->InitializeVideo();
+    if( !m_trackedVideoSource->InitializeVideo() )
+        return false;
 
-    // simtodo : don't always return true
     return true;
 }
 

--- a/IbisHardware/trackedvideosource.cpp
+++ b/IbisHardware/trackedvideosource.cpp
@@ -110,7 +110,7 @@ void TrackedVideoSource::SetSyncedTrackerTool( vtkTrackerTool * t )
     m_liveVideoBuffer->SetTrackerTool( t );
 }
 
-void TrackedVideoSource::InitializeVideo()
+bool TrackedVideoSource::InitializeVideo()
 {
     this->ClearVideo();
 
@@ -130,13 +130,15 @@ void TrackedVideoSource::InitializeVideo()
     }
 
     // Initialize with params applied
-    m_source->Initialize();
+    if( !m_source->Initialize() )
+        return false;
 
     // by default, current frame is -1. We want 0.
     m_source->GetBuffer()->Seek( 1 );
 
     if( m_numberOfClients > 0 )
         m_source->Record();
+    return true;
 }
 
 void TrackedVideoSource::ClearVideo()

--- a/IbisHardware/trackedvideosource.h
+++ b/IbisHardware/trackedvideosource.h
@@ -65,7 +65,7 @@ public:
 
     void SetSyncedTrackerTool( vtkTrackerTool * t );
 
-    void InitializeVideo();
+    bool InitializeVideo();
     void ClearVideo();
 
     // Description:

--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -327,6 +327,8 @@ void Application::InitHardware()
         m_updateManager->SetUpdatePeriod( (int)( 1000.0 / m_settings.UpdateFrequency )  );
         m_updateManager->Start();
     }
+    else
+        m_viewerOnly = true;
 }
 
 void Application::AddHardwareSettingsMenuEntries( QMenu * menu )

--- a/IbisPlugins/USManualCalibration/usmanualcalibrationplugininterface.cpp
+++ b/IbisPlugins/USManualCalibration/usmanualcalibrationplugininterface.cpp
@@ -52,8 +52,8 @@ USManualCalibrationPluginInterface::~USManualCalibrationPluginInterface()
 bool USManualCalibrationPluginInterface::CanRun()
 {
     // This plugin can't run in viewer-only mode. Needs video capture and tracking.
-    //if( m_application->IsViewerOnly() )
-    //    return false;
+    if( this->GetApplication()->IsViewerOnly() )
+        return false;
     return true;
 }
 


### PR DESCRIPTION
TrackedVideoSource::InitializeVideo() is boolean, returns false if vt…kVideoSource2::Initialize() returns false. IbisHardwareModule::Init() returns false if Tracker is not initialized or TrackedVideoSource::InitializeVideo() return false. Application::InitHardware() sets viewer only mode if any of the hardware modules is not initialized.USManualCalibrationPluginInterface::CanRun() returns false if Application is in viewr only mode.