### PR TITLE
Fixed crash in USManualCalibration 

### DIFF
--- a/IbisHardware/ibishardwaremodule.cpp
+++ b/IbisHardware/ibishardwaremodule.cpp
@@ -57,11 +57,13 @@ bool IbisHardwareModule::Init()
 
     // Init tracker
     m_tracker->Initialize();
+    if( !m_tracker->IsInitialized() )
+        return false;
 
     // Init video
-    m_trackedVideoSource->InitializeVideo();
+    if( !m_trackedVideoSource->InitializeVideo() )
+        return false;
 
-    // simtodo : don't always return true
     return true;
 }
 

--- a/IbisHardware/trackedvideosource.cpp
+++ b/IbisHardware/trackedvideosource.cpp
@@ -110,7 +110,7 @@ void TrackedVideoSource::SetSyncedTrackerTool( vtkTrackerTool * t )
     m_liveVideoBuffer->SetTrackerTool( t );
 }
 
-void TrackedVideoSource::InitializeVideo()
+bool TrackedVideoSource::InitializeVideo()
 {
     this->ClearVideo();
 
@@ -130,13 +130,15 @@ void TrackedVideoSource::InitializeVideo()
     }
 
     // Initialize with params applied
-    m_source->Initialize();
+    if( !m_source->Initialize() )
+        return false;
 
     // by default, current frame is -1. We want 0.
     m_source->GetBuffer()->Seek( 1 );
 
     if( m_numberOfClients > 0 )
         m_source->Record();
+    return true;
 }
 
 void TrackedVideoSource::ClearVideo()

--- a/IbisHardware/trackedvideosource.h
+++ b/IbisHardware/trackedvideosource.h
@@ -65,7 +65,7 @@ public:
 
     void SetSyncedTrackerTool( vtkTrackerTool * t );
 
-    void InitializeVideo();
+    bool InitializeVideo();
     void ClearVideo();
 
     // Description:

--- a/IbisPlugins/USAcquisition/doubleviewwidget.cpp
+++ b/IbisPlugins/USAcquisition/doubleviewwidget.cpp
@@ -18,7 +18,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "hardwaremodule.h"
 #include "guiutilities.h"
 
-#include <QMessageBox>
 #include "QVTKWidget.h"
 #include "vtkRenderWindowInteractor.h"
 #include "vtkInteractorStyleImage2.h"

--- a/IbisPlugins/USManualCalibration/usmanualcalibrationplugininterface.cpp
+++ b/IbisPlugins/USManualCalibration/usmanualcalibrationplugininterface.cpp
@@ -18,6 +18,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "usprobeobject.h"
 #include <QtPlugin>
 #include <QSettings>
+#include <QMessageBox>
 
 const double phantomPoints[16][3] = { { 0, 5, 50 },
 { 50, 5, 50 },
@@ -59,10 +60,17 @@ bool USManualCalibrationPluginInterface::CanRun()
 
 QWidget * USManualCalibrationPluginInterface::CreateFloatingWidget()
 {
-    BuildCalibrationPhantomRepresentation();
-
     // Make sure the us probe is still available and find another one if it is not
     ValidateUsProbe();
+
+    if( m_usProbeObjectId == SceneManager::InvalidId )
+    {
+        QString message( "No valid probe detected." );
+        QMessageBox::critical( 0, "Error", message, 1, 0 );
+        return 0;
+    }
+
+    BuildCalibrationPhantomRepresentation();
 
     USManualCalibrationWidget * calibrationWidget = new USManualCalibrationWidget;
     calibrationWidget->SetPluginInterface( this );


### PR DESCRIPTION
If there is no probe, display error message and do not build floating widget. Check tracker and video initialization. 