### PR TITLE
Fixed setting registration transform

### DIFF
--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -558,13 +558,13 @@ void LandmarkRegistrationObject::RegisterObject( bool on )
     {
         m_registrationTransform->UpdateRegistrationTransform();
         vtkSmartPointer<vtkTransform> tmpTrans = vtkSmartPointer<vtkTransform>::New();
-        tmpTrans->GetMatrix()->DeepCopy(m_registrationTransform->GetRegistrationTransform()->GetMatrix() );
+        tmpTrans->SetInput( m_registrationTransform->GetRegistrationTransform() );
         this->SetLocalTransform(tmpTrans.GetPointer());
         m_isRegistered = true;
     }
     else
     {
-        this->SetLocalTransform(m_backUpTransform);
+        this->SetLocalTransform(m_backUpTransform.GetPointer());
         m_isRegistered = false;
     }
 }

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -558,7 +558,7 @@ void LandmarkRegistrationObject::RegisterObject( bool on )
     {
         m_registrationTransform->UpdateRegistrationTransform();
         vtkSmartPointer<vtkTransform> tmpTrans = vtkSmartPointer<vtkTransform>::New();
-        tmpTrans->GetMatrix()->DeepCopy( m_registrationTransform->GetRegistrationTransform()->GetMatrix() );
+        tmpTrans->SetInput( m_registrationTransform->GetRegistrationTransform() );
         this->SetLocalTransform(tmpTrans.GetPointer());
         m_isRegistered = true;
     }

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -558,7 +558,7 @@ void LandmarkRegistrationObject::RegisterObject( bool on )
     {
         m_registrationTransform->UpdateRegistrationTransform();
         vtkSmartPointer<vtkTransform> tmpTrans = vtkSmartPointer<vtkTransform>::New();
-        tmpTrans->SetInput( m_registrationTransform->GetRegistrationTransform() );
+        tmpTrans->GetMatrix()->DeepCopy( m_registrationTransform->GetRegistrationTransform()->GetMatrix() );
         this->SetLocalTransform(tmpTrans.GetPointer());
         m_isRegistered = true;
     }


### PR DESCRIPTION
We use now computed vtkLandmarkTransform as input to the LocalTransform of LandmarkRegistrationObject.
Fixes selecting LandmarkRegistrationObject tags and showing mr slices in DoubleViewWindow.