### PR TITLE
Convert images ITK to VTK and VTK to ITK

### DIFF
--- a/IbisITK/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.h
+++ b/IbisITK/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.h
@@ -15,6 +15,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 #include "itkObject.h"
 #include "itkOpenCLUtil.h"
+#include <itkImage.h>
 
 #include "vnl/vnl_matrix_fixed.h"
 #include "vnl/vnl_inverse.h"

--- a/IbisLib/CMakeLists.txt
+++ b/IbisLib/CMakeLists.txt
@@ -33,6 +33,7 @@ SET( IBISLIB_SRC
                      simplepropcreator.cpp
                      ibismath.cpp
                      ibisplugin.cpp
+                     ibisitkvtkconverter.cpp
                      gui/aboutbicigns.cpp
                      gui/aboutpluginswidget.cpp
                      gui/trackerstatusdialog.cpp
@@ -74,6 +75,7 @@ SET( IBISLIB_HDR
                      linesfactory.h
                      simplepropcreator.h
                      ibismath.h
+                     ibisitkvtkconverter.h
                      gui/guiutilities.h )
 
 SET( IBISLIB_HDR_MOC

--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -509,9 +509,10 @@ void Application::OpenFiles( OpenFileParams * params, bool addToScene )
     m_progressDialogUpdateTimer = 0;
 }
 
-bool Application::GetImageDataFromVideoFrame(QString fileName, ImageObject *img )
+bool Application::GetImageDataFromVideoFrame(QString fileName, vtkImageData *img, vtkMatrix4x4 *mat )
 {
     Q_ASSERT(img);
+    Q_ASSERT(mat);
     m_fileReader = new FileReader;
     QFileInfo fi( fileName );
     if( !(fi.isReadable()) )
@@ -521,7 +522,7 @@ bool Application::GetImageDataFromVideoFrame(QString fileName, ImageObject *img 
         QMessageBox::critical( 0, "Error", message, 1, 0 );
         return false;
     }
-    bool ok = m_fileReader->GetFrameDataFromMINCFile( fileName, img );
+    bool ok = m_fileReader->GetFrameDataFromMINCFile( fileName, img, mat );
     delete m_fileReader;
     return ok;
 }

--- a/IbisLib/application.h
+++ b/IbisLib/application.h
@@ -40,6 +40,7 @@ class QProgressDialog;
 class QTimer;
 class QDialog;
 class vtkMatrix4x4;
+class vtkImageData;
 class MainWindow;
 class ImageObject;
 class PointsObject;
@@ -145,7 +146,7 @@ public:
     void ImportCamera();
 
     // Getting data from files
-    bool GetImageDataFromVideoFrame(QString fileName, ImageObject *img );
+    bool GetImageDataFromVideoFrame(QString fileName, vtkImageData *img , vtkMatrix4x4 *mat );
     bool GetPointsFromTagFile(QString fileName, PointsObject *pts1, PointsObject *pts2 );
 
     // Useful modal dialog

--- a/IbisLib/filereader.cpp
+++ b/IbisLib/filereader.cpp
@@ -397,7 +397,7 @@ void FileReader::PrintMetadata(itk::MetaDataDictionary &dict)
 bool FileReader::OpenItkFile( QList<SceneObject*> & readObjects, QString filename, const QString & dataObjectName )
 {
     // try to read
-    typedef itk::ImageFileReader< IbisItk3DImageType > ReaderType;
+    typedef itk::ImageFileReader< IbisItkFloat3ImageType > ReaderType;
     ReaderType::Pointer reader = ReaderType::New();
     reader->SetFileName(filename.toUtf8().data());
 
@@ -412,7 +412,7 @@ bool FileReader::OpenItkFile( QList<SceneObject*> & readObjects, QString filenam
     // Update progress. simtodo : do something smarter. Itk minc reader doesn't seem to support progress.
     ReaderProgress( .5 );
 
-    IbisItk3DImageType::Pointer itkImage = reader->GetOutput();
+    IbisItkFloat3ImageType::Pointer itkImage = reader->GetOutput();
     ImageObject * image = ImageObject::New();
     image->SetItkImage( itkImage );
 
@@ -430,7 +430,7 @@ bool FileReader::OpenItkFile( QList<SceneObject*> & readObjects, QString filenam
 bool FileReader::OpenItkLabelFile( QList<SceneObject*> & readObjects, QString filename, const QString & dataObjectName )
 {
     // try to read
-    typedef itk::ImageFileReader< IbisItk3DLabelType > ReaderType;
+    typedef itk::ImageFileReader< IbisItkUnsignedChar3ImageType > ReaderType;
     ReaderType::Pointer reader = ReaderType::New();
     reader->SetFileName( filename.toUtf8().data() );
 
@@ -445,7 +445,7 @@ bool FileReader::OpenItkLabelFile( QList<SceneObject*> & readObjects, QString fi
     // Update progress. simtodo : do something smarter. Itk minc reader doesn't seem to support progress.
     ReaderProgress( .5 );
 
-    IbisItk3DLabelType::Pointer itkImage = reader->GetOutput();
+    IbisItkUnsignedChar3ImageType::Pointer itkImage = reader->GetOutput();
     ImageObject * image = ImageObject::New();
     image->SetItkLabelImage( itkImage );
 

--- a/IbisLib/filereader.cpp
+++ b/IbisLib/filereader.cpp
@@ -26,7 +26,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "imageobject.h"
 #include "polydataobject.h"
 #include "pointsobject.h"
-#include "ibisitkvtkconverter.h"
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>

--- a/IbisLib/filereader.h
+++ b/IbisLib/filereader.h
@@ -20,6 +20,8 @@ class SceneManager;
 class SceneObject;
 class vtkEventQtSlotConnect;
 class vtkObject;
+class vtkImageData;
+class vtkMatrix4x4;
 class ImageObject;
 class PointsObject;
 
@@ -82,7 +84,7 @@ public:
     bool FindMincConverter();
     bool IsMINC1( QString fileName );
     bool ConvertMINC1toMINC2(QString &inputileName, QString &outputileName , bool isVideoFrame = false );
-    bool GetFrameDataFromMINCFile(QString filename, ImageObject *img);
+    bool GetFrameDataFromMINCFile(QString filename, vtkImageData *img , vtkMatrix4x4 *mat );
     bool GetPointsDataFromTagFile( QString filename, PointsObject *pts1, PointsObject *pts2 );
 
 private slots:

--- a/IbisLib/ibisitkvtkconverter.cpp
+++ b/IbisLib/ibisitkvtkconverter.cpp
@@ -1,0 +1,103 @@
+#include "ibisitkvtkconverter.h"
+#include "vtkImageImport.h"
+
+template< class TInputImage >
+IbisItkVTKImageExport< TInputImage >::IbisItkVTKImageExport()
+{
+    for( int i = 0; i < 3; ++i )
+        vtkOrigin[ i ] = 0.0;
+}
+
+template< class TInputImage >
+double * IbisItkVTKImageExport< TInputImage >::OriginCallback()
+{
+    // run base class
+    double * orig = itk::VTKImageExport< TInputImage >::OriginCallback();
+
+    // Get inverse of the dir cosine matrix
+    InputImagePointer input = this->GetInput();
+    itk::Matrix< double, 3, 3 > dir_cos = input->GetDirection();
+    vnl_matrix_fixed< double, 3, 3 > inv_dir_cos = dir_cos.GetTranspose();
+
+    // Transform the origin back to the way vtk sees it
+    vnl_vector_fixed< double, 3 > origin;
+    vnl_vector_fixed< double, 3 > o_origin;
+    for( int j = 0; j < 3; j++ )
+        o_origin[ j ] = orig[ j ];
+    origin = inv_dir_cos * o_origin;
+
+    for( int i = 0; i < 3; ++i )
+        vtkOrigin[ i ] = origin[ i ];
+
+    return vtkOrigin;
+}
+
+
+IbisItkVtkConverter::IbisItkVtkConverter()
+{
+    this->ItkToVtkImporter = 0;
+}
+
+IbisItkVtkConverter::~IbisItkVtkConverter()
+{
+    this->ItkToVtkImporter->Delete();
+}
+
+ItkExporterType::Pointer IbisItkVtkConverter::GetItktoVtkExporter()
+{
+    this->BuildItkToVtkExport();
+    return this->ItkToVtkExporter;
+}
+
+ItkRGBImageExporterType::Pointer IbisItkVtkConverter::GetItkRGBImageExporter()
+{
+    this->BuildItkRGBImageToVtkExport();
+    return this->ItkRGBImageToVtkExporter;
+}
+
+IbisItkUnsignedChar3ExporterType::Pointer IbisItkVtkConverter::GetItkUnsignedChar3ExporterType()
+{
+    this->BuildItkToVtkUnsignedChar3Export();
+    return this->ItkToVtkUnsignedChar3lExporter;
+}
+
+vtkImageImport * IbisItkVtkConverter::GetVtkImageImporter()
+{
+    return this->ItkToVtkImporter;
+}
+
+void IbisItkVtkConverter::BuildItkToVtkExport()
+{
+    this->ItkToVtkExporter = ItkExporterType::New();
+    BuildVtkImport( this->ItkToVtkExporter );
+}
+
+void IbisItkVtkConverter::BuildItkRGBImageToVtkExport()
+{
+    this->ItkRGBImageToVtkExporter = ItkRGBImageExporterType::New();
+    BuildVtkImport( this->ItkRGBImageToVtkExporter );
+}
+
+
+void IbisItkVtkConverter::BuildItkToVtkUnsignedChar3Export()
+{
+    this->ItkToVtkUnsignedChar3lExporter = IbisItkUnsignedChar3ExporterType::New();
+    BuildVtkImport( this->ItkToVtkUnsignedChar3lExporter );
+}
+
+void IbisItkVtkConverter::BuildVtkImport( itk::VTKImageExportBase * exporter )
+{
+    this->ItkToVtkImporter = vtkImageImport::New();
+    this->ItkToVtkImporter->SetUpdateInformationCallback( exporter->GetUpdateInformationCallback() );
+    this->ItkToVtkImporter->SetPipelineModifiedCallback( exporter->GetPipelineModifiedCallback() );
+    this->ItkToVtkImporter->SetWholeExtentCallback( exporter->GetWholeExtentCallback() );
+    this->ItkToVtkImporter->SetSpacingCallback( exporter->GetSpacingCallback() );
+    this->ItkToVtkImporter->SetOriginCallback( exporter->GetOriginCallback() );
+    this->ItkToVtkImporter->SetScalarTypeCallback( exporter->GetScalarTypeCallback() );
+    this->ItkToVtkImporter->SetNumberOfComponentsCallback( exporter->GetNumberOfComponentsCallback() );
+    this->ItkToVtkImporter->SetPropagateUpdateExtentCallback( exporter->GetPropagateUpdateExtentCallback() );
+    this->ItkToVtkImporter->SetUpdateDataCallback( exporter->GetUpdateDataCallback() );
+    this->ItkToVtkImporter->SetDataExtentCallback( exporter->GetDataExtentCallback() );
+    this->ItkToVtkImporter->SetBufferPointerCallback( exporter->GetBufferPointerCallback() );
+    this->ItkToVtkImporter->SetCallbackUserData( exporter->GetCallbackUserData() );
+}

--- a/IbisLib/ibisitkvtkconverter.cpp
+++ b/IbisLib/ibisitkvtkconverter.cpp
@@ -1,6 +1,7 @@
 #include "ibisitkvtkconverter.h"
 #include "vtkImageImport.h"
 #include "vtkImageData.h"
+#include "vtkMatrix4x4.h"
 
 template< class TInputImage >
 IbisItkVTKImageExport< TInputImage >::IbisItkVTKImageExport()
@@ -44,7 +45,16 @@ IbisItkVtkConverter::~IbisItkVtkConverter()
     this->ItkToVtkImporter->Delete();
 }
 
-vtkImageData * IbisItkVtkConverter::ConvertItkFloat3ImageToVtkImage( IbisItkFloat3ImageType::Pointer img )
+//template< class T > void IbisItkVtkConverter::GetImageTransform( T img, vtkMatrix4x4 *mat )
+//{
+//    itk::Matrix< double, 3, 3 > dirCosines = img->GetDirection();
+//    vtkMatrix4x4 * rotMat = vtkMatrix4x4::New();
+//    for( unsigned i = 0; i < 3; ++i )
+//        for( unsigned j = 0; j < 3; ++j )
+//            mat->SetElement( i, j, dirCosines( i, j ) );
+//}
+
+vtkImageData * IbisItkVtkConverter::ConvertItkImageToVtkImage( IbisItkFloat3ImageType::Pointer img )
 {
     this->ItkToVtkExporter = ItkExporterType::New();
     BuildVtkImport( this->ItkToVtkExporter );
@@ -53,7 +63,7 @@ vtkImageData * IbisItkVtkConverter::ConvertItkFloat3ImageToVtkImage( IbisItkFloa
     return this->ItkToVtkImporter->GetOutput();
 }
 
-vtkImageData * IbisItkVtkConverter::ConvertItkRGBImageToVtkImage( IbisRGBImageType::Pointer img )
+vtkImageData * IbisItkVtkConverter::ConvertItkImageToVtkImage( IbisRGBImageType::Pointer img )
 {
     this->ItkRGBImageToVtkExporter = ItkRGBImageExporterType::New();
     BuildVtkImport( this->ItkRGBImageToVtkExporter );
@@ -62,7 +72,7 @@ vtkImageData * IbisItkVtkConverter::ConvertItkRGBImageToVtkImage( IbisRGBImageTy
     return this->ItkToVtkImporter->GetOutput();
 }
 
-vtkImageData * IbisItkVtkConverter::ConvertItkUnsignedChar3ImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img )
+vtkImageData * IbisItkVtkConverter::ConvertItkImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img )
 {
     this->ItkToVtkUnsignedChar3lExporter = IbisItkUnsignedChar3ExporterType::New();
     BuildVtkImport( this->ItkToVtkUnsignedChar3lExporter );

--- a/IbisLib/ibisitkvtkconverter.cpp
+++ b/IbisLib/ibisitkvtkconverter.cpp
@@ -1,5 +1,6 @@
 #include "ibisitkvtkconverter.h"
 #include "vtkImageImport.h"
+#include "vtkImageData.h"
 
 template< class TInputImage >
 IbisItkVTKImageExport< TInputImage >::IbisItkVTKImageExport()
@@ -43,46 +44,31 @@ IbisItkVtkConverter::~IbisItkVtkConverter()
     this->ItkToVtkImporter->Delete();
 }
 
-ItkExporterType::Pointer IbisItkVtkConverter::GetItktoVtkExporter()
-{
-    this->BuildItkToVtkExport();
-    return this->ItkToVtkExporter;
-}
-
-ItkRGBImageExporterType::Pointer IbisItkVtkConverter::GetItkRGBImageExporter()
-{
-    this->BuildItkRGBImageToVtkExport();
-    return this->ItkRGBImageToVtkExporter;
-}
-
-IbisItkUnsignedChar3ExporterType::Pointer IbisItkVtkConverter::GetItkUnsignedChar3ExporterType()
-{
-    this->BuildItkToVtkUnsignedChar3Export();
-    return this->ItkToVtkUnsignedChar3lExporter;
-}
-
-vtkImageImport * IbisItkVtkConverter::GetVtkImageImporter()
-{
-    return this->ItkToVtkImporter;
-}
-
-void IbisItkVtkConverter::BuildItkToVtkExport()
+vtkImageData * IbisItkVtkConverter::ConvertItkFloat3ImageToVtkImage( IbisItkFloat3ImageType::Pointer img )
 {
     this->ItkToVtkExporter = ItkExporterType::New();
     BuildVtkImport( this->ItkToVtkExporter );
+    this->ItkToVtkExporter->SetInput( img );
+    this->ItkToVtkImporter->Update();
+    return this->ItkToVtkImporter->GetOutput();
 }
 
-void IbisItkVtkConverter::BuildItkRGBImageToVtkExport()
+vtkImageData * IbisItkVtkConverter::ConvertItkRGBImageToVtkImage( IbisRGBImageType::Pointer img )
 {
     this->ItkRGBImageToVtkExporter = ItkRGBImageExporterType::New();
     BuildVtkImport( this->ItkRGBImageToVtkExporter );
+    this->ItkRGBImageToVtkExporter->SetInput( img );
+    this->ItkToVtkImporter->Update();
+    return this->ItkToVtkImporter->GetOutput();
 }
 
-
-void IbisItkVtkConverter::BuildItkToVtkUnsignedChar3Export()
+vtkImageData * IbisItkVtkConverter::ConvertItkUnsignedChar3ImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img )
 {
     this->ItkToVtkUnsignedChar3lExporter = IbisItkUnsignedChar3ExporterType::New();
     BuildVtkImport( this->ItkToVtkUnsignedChar3lExporter );
+    this->ItkToVtkUnsignedChar3lExporter->SetInput( img );
+    this->ItkToVtkImporter->Update();
+    return this->ItkToVtkImporter->GetOutput();
 }
 
 void IbisItkVtkConverter::BuildVtkImport( itk::VTKImageExportBase * exporter )

--- a/IbisLib/ibisitkvtkconverter.cpp
+++ b/IbisLib/ibisitkvtkconverter.cpp
@@ -5,6 +5,7 @@
 #include "vtkImageShiftScale.h"
 #include "vtkImageLuminance.h"
 #include "vtkMath.h"
+#include "vtkSmartPointer.h"
 
 template< class TInputImage >
 IbisItkVTKImageExport< TInputImage >::IbisItkVTKImageExport()
@@ -117,7 +118,7 @@ bool IbisItkVtkConverter::ConvertVtkImageToItkImage( IbisItkFloat3ImageType::Poi
         return false;
     int numberOfScalarComponents = img->GetNumberOfScalarComponents();
     vtkImageData *grayImage = img;
-    vtkImageLuminance *luminanceFilter = vtkImageLuminance::New();
+    vtkSmartPointer<vtkImageLuminance> luminanceFilter = vtkSmartPointer<vtkImageLuminance>::New();
     if (numberOfScalarComponents > 1)
     {
         luminanceFilter->SetInputData(img);
@@ -125,7 +126,7 @@ bool IbisItkVtkConverter::ConvertVtkImageToItkImage( IbisItkFloat3ImageType::Poi
         grayImage = luminanceFilter->GetOutput();
     }
     vtkImageData * image = grayImage;
-    vtkImageShiftScale *shifter = vtkImageShiftScale::New();
+    vtkSmartPointer<vtkImageShiftScale> shifter = vtkSmartPointer<vtkImageShiftScale>::New();
     if (img->GetScalarType() != VTK_FLOAT)
     {
         shifter->SetOutputScalarType(VTK_FLOAT);
@@ -156,7 +157,7 @@ bool IbisItkVtkConverter::ConvertVtkImageToItkImage( IbisItkFloat3ImageType::Poi
     itk::Vector< double, 3 > origin;
     itk::Vector< double, 3 > itkOrigin;
     // set direction cosines
-    vtkMatrix4x4 * tmpMat = vtkMatrix4x4::New();
+    vtkSmartPointer<vtkMatrix4x4> tmpMat = vtkSmartPointer<vtkMatrix4x4>::New();
     vtkMatrix4x4::Transpose( imageMatrix, tmpMat );
     double step[3], mincStartPoint[3], dirCos[3][3];
     for( int i = 0; i < 3; i++ )
@@ -183,9 +184,6 @@ bool IbisItkVtkConverter::ConvertVtkImageToItkImage( IbisItkFloat3ImageType::Poi
     itkOutputImage->Allocate();
     float *itkImageBuffer = itkOutputImage->GetBufferPointer();
     memcpy(itkImageBuffer, image->GetScalarPointer(), numberOfPixels*sizeof(float));
-    tmpMat->Delete();
-    shifter->Delete();
-    luminanceFilter->Delete();
     return true;
 }
 
@@ -213,7 +211,7 @@ bool IbisItkVtkConverter::ConvertVtkImageToItkImage( IbisRGBImageType::Pointer i
     itk::Vector< double, 3 > origin;
     itk::Vector< double, 3 > itkOrigin;
     // set direction cosines
-    vtkMatrix4x4 * tmpMat = vtkMatrix4x4::New();
+    vtkSmartPointer<vtkMatrix4x4> tmpMat = vtkSmartPointer<vtkMatrix4x4>::New();
     vtkMatrix4x4::Transpose( imageMatrix, tmpMat );
     double step[3], mincStartPoint[3], dirCos[3][3];
     for( int i = 0; i < 3; i++ )
@@ -241,7 +239,6 @@ bool IbisItkVtkConverter::ConvertVtkImageToItkImage( IbisRGBImageType::Pointer i
     itkOutputImage->Allocate();
     RGBPixelType *itkImageBuffer = itkOutputImage->GetBufferPointer();
     memcpy(itkImageBuffer, image->GetScalarPointer(), numberOfPixels*sizeof(RGBPixelType));
-    tmpMat->Delete();
     return true;
 }
 
@@ -269,7 +266,7 @@ bool IbisItkVtkConverter::ConvertVtkImageToItkImage( IbisItkUnsignedChar3ImageTy
     itk::Vector< double, 3 > origin;
     itk::Vector< double, 3 > itkOrigin;
     // set direction cosines
-    vtkMatrix4x4 * tmpMat = vtkMatrix4x4::New();
+    vtkSmartPointer<vtkMatrix4x4> tmpMat = vtkSmartPointer<vtkMatrix4x4>::New();
     vtkMatrix4x4::Transpose( imageMatrix, tmpMat );
     double step[3], mincStartPoint[3], dirCos[3][3];
     for( int i = 0; i < 3; i++ )
@@ -296,6 +293,5 @@ bool IbisItkVtkConverter::ConvertVtkImageToItkImage( IbisItkUnsignedChar3ImageTy
     itkOutputImage->Allocate();
     unsigned char *itkImageBuffer = itkOutputImage->GetBufferPointer();
     memcpy(itkImageBuffer, image->GetScalarPointer(), numberOfPixels*sizeof(unsigned char));
-    tmpMat->Delete();
     return true;
 }

--- a/IbisLib/ibisitkvtkconverter.h
+++ b/IbisLib/ibisitkvtkconverter.h
@@ -34,28 +34,25 @@ typedef IbisItkVTKImageExport< IbisItkUnsignedChar3ImageType > IbisItkUnsignedCh
 
 
 class vtkImageImport;
+class vtkImageData;
 
 class IbisItkVtkConverter : public vtkObject
 {
 public:
     static IbisItkVtkConverter * New() { return new IbisItkVtkConverter; }
 
-    vtkTypeMacro(IbisItkVtkConverter,vtkObject);
+    vtkTypeMacro(IbisItkVtkConverter,vtkObject)
 
     IbisItkVtkConverter();
      virtual ~IbisItkVtkConverter();
 
-    ItkExporterType::Pointer GetItktoVtkExporter();
-    ItkRGBImageExporterType::Pointer GetItkRGBImageExporter();
-    IbisItkUnsignedChar3ExporterType::Pointer GetItkUnsignedChar3ExporterType();
-    vtkImageImport *GetVtkImageImporter();
+    vtkImageData *ConvertItkFloat3ImageToVtkImage( IbisItkFloat3ImageType::Pointer img );
+    vtkImageData *ConvertItkRGBImageToVtkImage( IbisRGBImageType::Pointer img );
+    vtkImageData *ConvertItkUnsignedChar3ImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img );
 
 protected:
-    void BuildItkToVtkExport();
-    void BuildItkRGBImageToVtkExport();
-    void BuildItkToVtkUnsignedChar3Export();
-    void BuildVtkImport( itk::VTKImageExportBase * exporter );
 
+    void BuildVtkImport( itk::VTKImageExportBase * exporter );
 
     ItkExporterType::Pointer ItkToVtkExporter;
     ItkRGBImageExporterType::Pointer ItkRGBImageToVtkExporter;

--- a/IbisLib/ibisitkvtkconverter.h
+++ b/IbisLib/ibisitkvtkconverter.h
@@ -36,6 +36,7 @@ typedef IbisItkVTKImageExport< IbisItkUnsignedChar3ImageType > IbisItkUnsignedCh
 class vtkImageImport;
 class vtkImageData;
 class vtkTransform;
+class vtkMatrix4x4;
 
 class IbisItkVtkConverter : public vtkObject
 {
@@ -51,6 +52,7 @@ public:
     vtkImageData *ConvertItkImageToVtkImage(IbisRGBImageType::Pointer img , vtkTransform *tr);
     vtkImageData *ConvertItkImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img, vtkTransform *tr );
 
+    bool ConvertVtkImageToItkImage( IbisItkFloat3ImageType::Pointer itkOutputImage, vtkImageData *slice, vtkMatrix4x4 *calibratedSliceMatrix);
 
 protected:
 

--- a/IbisLib/ibisitkvtkconverter.h
+++ b/IbisLib/ibisitkvtkconverter.h
@@ -35,7 +35,7 @@ typedef IbisItkVTKImageExport< IbisItkUnsignedChar3ImageType > IbisItkUnsignedCh
 
 class vtkImageImport;
 class vtkImageData;
-class vtkMatrix4x4;
+class vtkTransform;
 
 class IbisItkVtkConverter : public vtkObject
 {
@@ -47,11 +47,10 @@ public:
     IbisItkVtkConverter();
      virtual ~IbisItkVtkConverter();
 
-    vtkImageData *ConvertItkImageToVtkImage( IbisItkFloat3ImageType::Pointer img );
-    vtkImageData *ConvertItkImageToVtkImage( IbisRGBImageType::Pointer img );
-    vtkImageData *ConvertItkImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img );
+    vtkImageData *ConvertItkImageToVtkImage( IbisItkFloat3ImageType::Pointer img, vtkTransform *tr );
+    vtkImageData *ConvertItkImageToVtkImage(IbisRGBImageType::Pointer img , vtkTransform *tr);
+    vtkImageData *ConvertItkImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img, vtkTransform *tr );
 
-//    template< class T > void GetImageTransform( T img, vtkMatrix4x4 *mat );
 
 protected:
 
@@ -61,6 +60,9 @@ protected:
     ItkRGBImageExporterType::Pointer ItkRGBImageToVtkExporter;
     IbisItkUnsignedChar3ExporterType::Pointer ItkToVtkUnsignedChar3lExporter;
     vtkImageImport *ItkToVtkImporter;
+
+private:
+    void GetImageTransformFromDirectionCosines( itk::Matrix< double, 3, 3 > dirCosines, vtkTransform *tr );
 
 };
 

--- a/IbisLib/ibisitkvtkconverter.h
+++ b/IbisLib/ibisitkvtkconverter.h
@@ -1,0 +1,67 @@
+#ifndef IBISITKVTKCONVERTER_H
+#define IBISITKVTKCONVERTER_H
+
+#include "itkVTKImageExport.h"
+#include <itkImageRegionIterator.h>
+#include <itkImage.h>
+#include "itkRGBPixel.h"
+#include "vtkObject.h"
+
+typedef itk::RGBPixel< unsigned char > RGBPixelType;
+typedef itk::Image< RGBPixelType, 3 > IbisRGBImageType;
+typedef itk::Image<float,3> IbisItkFloat3ImageType;
+typedef itk::Image < unsigned char,3 > IbisItkUnsignedChar3ImageType;
+typedef itk::ImageRegionIterator< IbisItkFloat3ImageType > IbisItkFloat3ImageIteratorType;
+
+//// Reimplement origin callback from itk::VTKImageExport to take dir cosines into account correctly
+template< class TInputImage >
+class IbisItkVTKImageExport : public itk::VTKImageExport< TInputImage >
+{
+public:
+    typedef IbisItkVTKImageExport<TInputImage>   Self;
+    typedef itk::SmartPointer< Self >            Pointer;
+    typedef TInputImage InputImageType;
+    itkNewMacro(Self);
+protected:
+    typedef typename InputImageType::Pointer    InputImagePointer;
+    IbisItkVTKImageExport();
+    double * OriginCallback() override;
+    double vtkOrigin[3];
+};
+typedef IbisItkVTKImageExport< IbisItkFloat3ImageType > ItkExporterType;
+typedef IbisItkVTKImageExport< IbisRGBImageType > ItkRGBImageExporterType;
+typedef IbisItkVTKImageExport< IbisItkUnsignedChar3ImageType > IbisItkUnsignedChar3ExporterType;
+
+
+class vtkImageImport;
+
+class IbisItkVtkConverter : public vtkObject
+{
+public:
+    static IbisItkVtkConverter * New() { return new IbisItkVtkConverter; }
+
+    vtkTypeMacro(IbisItkVtkConverter,vtkObject);
+
+    IbisItkVtkConverter();
+     virtual ~IbisItkVtkConverter();
+
+    ItkExporterType::Pointer GetItktoVtkExporter();
+    ItkRGBImageExporterType::Pointer GetItkRGBImageExporter();
+    IbisItkUnsignedChar3ExporterType::Pointer GetItkUnsignedChar3ExporterType();
+    vtkImageImport *GetVtkImageImporter();
+
+protected:
+    void BuildItkToVtkExport();
+    void BuildItkRGBImageToVtkExport();
+    void BuildItkToVtkUnsignedChar3Export();
+    void BuildVtkImport( itk::VTKImageExportBase * exporter );
+
+
+    ItkExporterType::Pointer ItkToVtkExporter;
+    ItkRGBImageExporterType::Pointer ItkRGBImageToVtkExporter;
+    IbisItkUnsignedChar3ExporterType::Pointer ItkToVtkUnsignedChar3lExporter;
+    vtkImageImport *ItkToVtkImporter;
+
+};
+
+#endif // IBISITKVTKCONVERTER_H

--- a/IbisLib/ibisitkvtkconverter.h
+++ b/IbisLib/ibisitkvtkconverter.h
@@ -52,7 +52,9 @@ public:
     vtkImageData *ConvertItkImageToVtkImage(IbisRGBImageType::Pointer img , vtkTransform *tr);
     vtkImageData *ConvertItkImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img, vtkTransform *tr );
 
-    bool ConvertVtkImageToItkImage( IbisItkFloat3ImageType::Pointer itkOutputImage, vtkImageData *slice, vtkMatrix4x4 *calibratedSliceMatrix);
+    bool ConvertVtkImageToItkImage( IbisItkFloat3ImageType::Pointer itkOutputImage, vtkImageData *image, vtkMatrix4x4 *imageMatrix );
+    bool ConvertVtkImageToItkImage( IbisRGBImageType::Pointer itkOutputImage, vtkImageData *image, vtkMatrix4x4 *imageMatrix );
+    bool ConvertVtkImageToItkImage( IbisItkUnsignedChar3ImageType::Pointer itkOutputImage, vtkImageData *image, vtkMatrix4x4 *imageMatrix );
 
 protected:
 

--- a/IbisLib/ibisitkvtkconverter.h
+++ b/IbisLib/ibisitkvtkconverter.h
@@ -35,6 +35,7 @@ typedef IbisItkVTKImageExport< IbisItkUnsignedChar3ImageType > IbisItkUnsignedCh
 
 class vtkImageImport;
 class vtkImageData;
+class vtkMatrix4x4;
 
 class IbisItkVtkConverter : public vtkObject
 {
@@ -46,9 +47,11 @@ public:
     IbisItkVtkConverter();
      virtual ~IbisItkVtkConverter();
 
-    vtkImageData *ConvertItkFloat3ImageToVtkImage( IbisItkFloat3ImageType::Pointer img );
-    vtkImageData *ConvertItkRGBImageToVtkImage( IbisRGBImageType::Pointer img );
-    vtkImageData *ConvertItkUnsignedChar3ImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img );
+    vtkImageData *ConvertItkImageToVtkImage( IbisItkFloat3ImageType::Pointer img );
+    vtkImageData *ConvertItkImageToVtkImage( IbisRGBImageType::Pointer img );
+    vtkImageData *ConvertItkImageToVtkImage( IbisItkUnsignedChar3ImageType::Pointer img );
+
+//    template< class T > void GetImageTransform( T img, vtkMatrix4x4 *mat );
 
 protected:
 

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -9,7 +9,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
      PURPOSE.  See the above copyright notice for more information.
 =========================================================================*/
 #include <sstream>
-//#include "imageobject.h"
 #include "vtkOutlineFilter.h"
 #include "vtkPolyDataMapper.h"
 #include "vtkRenderer.h"
@@ -223,18 +222,6 @@ void ImageObject::SetItkImage( IbisItkFloat3ImageType::Pointer image )
     {
         vtkTransform * rotTrans = vtkTransform::New();
         this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkImage, rotTrans ) );
-        this->SetLocalTransform( rotTrans );
-        rotTrans->Delete();
-    }
-}
-
-void ImageObject::SetItkImage( IbisRGBImageType::Pointer image )
-{
-    this->ItkRGBImage = image;
-    if( this->ItkRGBImage )
-    {
-        vtkTransform * rotTrans = vtkTransform::New();
-        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkRGBImage, rotTrans ) );
         this->SetLocalTransform( rotTrans );
         rotTrans->Delete();
     }

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -221,18 +221,9 @@ void ImageObject::SetItkImage( IbisItkFloat3ImageType::Pointer image )
     this->ItkImage = image;
     if( this->ItkImage )
     {
-        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkImage ) );
-
-        // Use itk image's dir cosines as the local transform for this image
-        itk::Matrix< double, 3, 3 > dirCosines = this->ItkImage->GetDirection();
-        vtkMatrix4x4 * rotMat = vtkMatrix4x4::New();
-        for( unsigned i = 0; i < 3; ++i )
-            for( unsigned j = 0; j < 3; ++j )
-                rotMat->SetElement( i, j, dirCosines( i, j ) );
         vtkTransform * rotTrans = vtkTransform::New();
-        rotTrans->SetMatrix( rotMat );
+        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkImage, rotTrans ) );
         this->SetLocalTransform( rotTrans );
-        rotMat->Delete();
         rotTrans->Delete();
     }
 }
@@ -242,18 +233,9 @@ void ImageObject::SetItkImage( IbisRGBImageType::Pointer image )
     this->ItkRGBImage = image;
     if( this->ItkRGBImage )
     {
-        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkRGBImage ) );
-
-        // Use itk image's dir cosines as the local transform for this image
-        itk::Matrix< double, 3, 3 > dirCosines = this->ItkRGBImage->GetDirection();
-        vtkMatrix4x4 * rotMat = vtkMatrix4x4::New();
-        for( unsigned i = 0; i < 3; ++i )
-            for( unsigned j = 0; j < 3; ++j )
-                rotMat->SetElement( i, j, dirCosines( i, j ) );
         vtkTransform * rotTrans = vtkTransform::New();
-        rotTrans->SetMatrix( rotMat );
+        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkRGBImage, rotTrans ) );
         this->SetLocalTransform( rotTrans );
-        rotMat->Delete();
         rotTrans->Delete();
     }
 }
@@ -263,18 +245,9 @@ void ImageObject::SetItkLabelImage( IbisItkUnsignedChar3ImageType::Pointer image
     this->ItkLabelImage = image;
     if( this->ItkLabelImage )
     {
-        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkLabelImage ) );
-
-        // Use itk image's dir cosines as the local transform for this image
-        itk::Matrix< double, 3, 3 > dirCosines = this->ItkLabelImage->GetDirection();
-        vtkMatrix4x4 * rotMat = vtkMatrix4x4::New();
-        for( unsigned i = 0; i < 3; ++i )
-            for( unsigned j = 0; j < 3; ++j )
-                rotMat->SetElement( i, j, dirCosines( i, j ) );
         vtkTransform * rotTrans = vtkTransform::New();
-        rotTrans->SetMatrix( rotMat );
+        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkLabelImage, rotTrans ) );
         this->SetLocalTransform( rotTrans );
-        rotMat->Delete();
         rotTrans->Delete();
     }
 }

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -46,37 +46,6 @@ ObjectSerializationMacro( ImageObject );
 
 const int ImageObject::NumberOfBinsInHistogram = 256;
 
-//template< class TInputImage >
-//IbisItkVTKImageExport< TInputImage >::IbisItkVTKImageExport()
-//{
-//    for( int i = 0; i < 3; ++i )
-//        vtkOrigin[ i ] = 0.0;
-//}
-
-//template< class TInputImage >
-//double * IbisItkVTKImageExport< TInputImage >::OriginCallback()
-//{
-//    // run base class
-//    double * orig = itk::VTKImageExport< TInputImage >::OriginCallback();
-
-//    // Get inverse of the dir cosine matrix
-//    InputImagePointer input = this->GetInput();
-//    itk::Matrix< double, 3, 3 > dir_cos = input->GetDirection();
-//    vnl_matrix_fixed< double, 3, 3 > inv_dir_cos = dir_cos.GetTranspose();
-
-//    // Transform the origin back to the way vtk sees it
-//    vnl_vector_fixed< double, 3 > origin;
-//    vnl_vector_fixed< double, 3 > o_origin;
-//    for( int j = 0; j < 3; j++ )
-//        o_origin[ j ] = orig[ j ];
-//    origin = inv_dir_cos * o_origin;
-
-//    for( int i = 0; i < 3; ++i )
-//        vtkOrigin[ i ] = origin[ i ];
-
-//    return vtkOrigin;
-//}
-
 ImageObject::PerViewElements::PerViewElements()
 {
     this->outlineActor = 0;
@@ -252,7 +221,7 @@ void ImageObject::SetItkImage( IbisItkFloat3ImageType::Pointer image )
     this->ItkImage = image;
     if( this->ItkImage )
     {
-        this->SetImage( this->ItktovtkConverter->ConvertItkFloat3ImageToVtkImage( this->ItkImage ) );
+        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkImage ) );
 
         // Use itk image's dir cosines as the local transform for this image
         itk::Matrix< double, 3, 3 > dirCosines = this->ItkImage->GetDirection();
@@ -273,7 +242,7 @@ void ImageObject::SetItkImage( IbisRGBImageType::Pointer image )
     this->ItkRGBImage = image;
     if( this->ItkRGBImage )
     {
-        this->SetImage( this->ItktovtkConverter->ConvertItkRGBImageToVtkImage( this->ItkRGBImage ) );
+        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkRGBImage ) );
 
         // Use itk image's dir cosines as the local transform for this image
         itk::Matrix< double, 3, 3 > dirCosines = this->ItkRGBImage->GetDirection();
@@ -294,7 +263,7 @@ void ImageObject::SetItkLabelImage( IbisItkUnsignedChar3ImageType::Pointer image
     this->ItkLabelImage = image;
     if( this->ItkLabelImage )
     {
-        this->SetImage( this->ItktovtkConverter->ConvertItkUnsignedChar3ImageToVtkImage( this->ItkLabelImage ) );
+        this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkLabelImage ) );
 
         // Use itk image's dir cosines as the local transform for this image
         itk::Matrix< double, 3, 3 > dirCosines = this->ItkLabelImage->GetDirection();

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -18,10 +18,12 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <map>
 #include <QVector>
 
-#include "itkVTKImageExport.h"
-#include <itkImageRegionIterator.h>
-#include <itkImage.h>
-#include "itkRGBPixel.h"
+#include "ibisitkvtkconverter.h"
+
+//#include "itkVTKImageExport.h"
+//#include <itkImageRegionIterator.h>
+//#include <itkImage.h>
+//#include "itkRGBPixel.h"
 
 class vtkRenderer;
 class vtkRenderWindowInteractor;
@@ -38,30 +40,30 @@ class vtkImageAccumulate;
 class vtkVolumeProperty;
 class vtkImageData;
 
-typedef itk::RGBPixel< unsigned char > RGBPixelType;
-typedef itk::Image< RGBPixelType, 3 > IbisRGBImageType;
-typedef itk::Image<float,3> IbisItk3DImageType;
-typedef itk::Image < unsigned char,3 > IbisItk3DLabelType;
-typedef itk::ImageRegionIterator< IbisItk3DImageType > IbisItk3DImageIteratorType;
+//typedef itk::RGBPixel< unsigned char > RGBPixelType;
+//typedef itk::Image< RGBPixelType, 3 > IbisRGBImageType;
+//typedef itk::Image<float,3> IbisItkFloat3ImageType;
+//typedef itk::Image < unsigned char,3 > IbisItkUnsignedChar3ImageType;
+//typedef itk::ImageRegionIterator< IbisItkFloat3ImageType > IbisItk3DImageIteratorType;
 
 // Reimplement origin callback from itk::VTKImageExport to take dir cosines into account correctly
-template< class TInputImage >
-class IbisItkVTKImageExport : public itk::VTKImageExport< TInputImage >
-{
-public:
-    typedef IbisItkVTKImageExport<TInputImage>   Self;
-    typedef itk::SmartPointer< Self >            Pointer;
-    typedef TInputImage InputImageType;
-    itkNewMacro(Self);
-protected:
-    typedef typename InputImageType::Pointer    InputImagePointer;
-    IbisItkVTKImageExport();
-    double * OriginCallback() override;
-    double vtkOrigin[3];
-};
-typedef IbisItkVTKImageExport< IbisItk3DImageType > ItkExporterType;
-typedef IbisItkVTKImageExport< IbisRGBImageType > ItkRGBImageExporterType;
-typedef IbisItkVTKImageExport< IbisItk3DLabelType > ItkLabelExporterType;
+//template< class TInputImage >
+//class IbisItkVTKImageExport : public itk::VTKImageExport< TInputImage >
+//{
+//public:
+//    typedef IbisItkVTKImageExport<TInputImage>   Self;
+//    typedef itk::SmartPointer< Self >            Pointer;
+//    typedef TInputImage InputImageType;
+//    itkNewMacro(Self);
+//protected:
+//    typedef typename InputImageType::Pointer    InputImagePointer;
+//    IbisItkVTKImageExport();
+//    double * OriginCallback() override;
+//    double vtkOrigin[3];
+//};
+//typedef IbisItkVTKImageExport< IbisItkFloat3ImageType > ItkExporterType;
+//typedef IbisItkVTKImageExport< IbisRGBImageType > ItkRGBImageExporterType;
+//typedef IbisItkVTKImageExport< IbisItkUnsignedChar3ImageType > IbisItkUnsignedChar3ExporterType;
 
 class ImageObject : public SceneObject
 {
@@ -84,12 +86,12 @@ public:
     bool IsLabelImage();
     
     vtkImageData* GetImage( );
-    void SetItkImage( IbisItk3DImageType::Pointer image );  // for all others
+    void SetItkImage( IbisItkFloat3ImageType::Pointer image );  // for all others
     void SetItkImage( IbisRGBImageType::Pointer image );  // for RGB images
-    void SetItkLabelImage( IbisItk3DLabelType::Pointer image );  // for labels
-    IbisItk3DImageType::Pointer GetItkImage() { return this->ItkImage; }
+    void SetItkLabelImage( IbisItkUnsignedChar3ImageType::Pointer image );  // for labels
+    IbisItkFloat3ImageType::Pointer GetItkImage() { return this->ItkImage; }
     IbisRGBImageType::Pointer GetItkRGBImage() { return this->ItkRGBImage; }
-    IbisItk3DLabelType::Pointer GetItkLabelImage() { return this->ItkLabelImage; }
+    IbisItkUnsignedChar3ImageType::Pointer GetItkLabelImage() { return this->ItkLabelImage; }
     void SetImage( vtkImageData * image );
     void ForceUpdatePixels();
     
@@ -160,17 +162,18 @@ protected:
     // Setup histogram properties after new image is set.
     void SetupHistogramComputer( );
 
-    void BuildItkToVtkExport();
-    void BuildItkRGBImageToVtkExport();
-    void BuildItkToVtkLabelExport();
-    void BuildVtkImport( itk::VTKImageExportBase * exporter );
+//    void BuildItkToVtkExport();
+//    void BuildItkRGBImageToVtkExport();
+//    void BuildItkToVtkLabelExport();
+//    void BuildVtkImport( itk::VTKImageExportBase * exporter );
 
-    IbisItk3DImageType::Pointer ItkImage;
+    IbisItkVtkConverter *ItktovtkConverter;
+    IbisItkFloat3ImageType::Pointer ItkImage;
     ItkExporterType::Pointer ItkToVtkExporter;
     IbisRGBImageType::Pointer ItkRGBImage;
     ItkRGBImageExporterType::Pointer ItkRGBImageToVtkExporter;
-    IbisItk3DLabelType::Pointer ItkLabelImage;
-    ItkLabelExporterType::Pointer ItkToVtkLabelExporter;
+    IbisItkUnsignedChar3ImageType::Pointer ItkLabelImage;
+    IbisItkUnsignedChar3ExporterType::Pointer ItkToVtkLabelExporter;
     vtkSmartPointer<vtkImageImport> ItkToVtkImporter;
 
     vtkSmartPointer<vtkImageData> Image;

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -40,31 +40,6 @@ class vtkImageAccumulate;
 class vtkVolumeProperty;
 class vtkImageData;
 
-//typedef itk::RGBPixel< unsigned char > RGBPixelType;
-//typedef itk::Image< RGBPixelType, 3 > IbisRGBImageType;
-//typedef itk::Image<float,3> IbisItkFloat3ImageType;
-//typedef itk::Image < unsigned char,3 > IbisItkUnsignedChar3ImageType;
-//typedef itk::ImageRegionIterator< IbisItkFloat3ImageType > IbisItk3DImageIteratorType;
-
-// Reimplement origin callback from itk::VTKImageExport to take dir cosines into account correctly
-//template< class TInputImage >
-//class IbisItkVTKImageExport : public itk::VTKImageExport< TInputImage >
-//{
-//public:
-//    typedef IbisItkVTKImageExport<TInputImage>   Self;
-//    typedef itk::SmartPointer< Self >            Pointer;
-//    typedef TInputImage InputImageType;
-//    itkNewMacro(Self);
-//protected:
-//    typedef typename InputImageType::Pointer    InputImagePointer;
-//    IbisItkVTKImageExport();
-//    double * OriginCallback() override;
-//    double vtkOrigin[3];
-//};
-//typedef IbisItkVTKImageExport< IbisItkFloat3ImageType > ItkExporterType;
-//typedef IbisItkVTKImageExport< IbisRGBImageType > ItkRGBImageExporterType;
-//typedef IbisItkVTKImageExport< IbisItkUnsignedChar3ImageType > IbisItkUnsignedChar3ExporterType;
-
 class ImageObject : public SceneObject
 {
     

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -62,7 +62,6 @@ public:
     
     vtkImageData* GetImage( );
     void SetItkImage( IbisItkFloat3ImageType::Pointer image );  // for all others
-    void SetItkImage( IbisRGBImageType::Pointer image );  // for RGB images
     void SetItkLabelImage( IbisItkUnsignedChar3ImageType::Pointer image );  // for labels
     IbisItkFloat3ImageType::Pointer GetItkImage() { return this->ItkImage; }
     IbisRGBImageType::Pointer GetItkRGBImage() { return this->ItkRGBImage; }

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -93,7 +93,6 @@ public:
     IbisRGBImageType::Pointer GetItkRGBImage() { return this->ItkRGBImage; }
     IbisItkUnsignedChar3ImageType::Pointer GetItkLabelImage() { return this->ItkLabelImage; }
     void SetImage( vtkImageData * image );
-    void ForceUpdatePixels();
     
     // Implementation of parent virtual method
     virtual void ObjectAddedToScene();
@@ -162,21 +161,12 @@ protected:
     // Setup histogram properties after new image is set.
     void SetupHistogramComputer( );
 
-//    void BuildItkToVtkExport();
-//    void BuildItkRGBImageToVtkExport();
-//    void BuildItkToVtkLabelExport();
-//    void BuildVtkImport( itk::VTKImageExportBase * exporter );
-
     IbisItkVtkConverter *ItktovtkConverter;
     IbisItkFloat3ImageType::Pointer ItkImage;
-    ItkExporterType::Pointer ItkToVtkExporter;
     IbisRGBImageType::Pointer ItkRGBImage;
-    ItkRGBImageExporterType::Pointer ItkRGBImageToVtkExporter;
     IbisItkUnsignedChar3ImageType::Pointer ItkLabelImage;
-    IbisItkUnsignedChar3ExporterType::Pointer ItkToVtkLabelExporter;
-    vtkSmartPointer<vtkImageImport> ItkToVtkImporter;
 
-    vtkSmartPointer<vtkImageData> Image;
+    vtkImageData* Image;
     vtkSmartPointer<vtkScalarsToColors> Lut;
     vtkSmartPointer<vtkOutlineFilter> OutlineFilter;
     static const int NumberOfBinsInHistogram;

--- a/IbisLib/usacquisitionobject.cpp
+++ b/IbisLib/usacquisitionobject.cpp
@@ -779,29 +779,33 @@ void USAcquisitionObject::GetFrameData(int index, vtkImageData *slice, vtkMatrix
     slice->DeepCopy( m_videoBuffer->GetImage( index ) );
 }
 
-bool USAcquisitionObject::GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform, vtkMatrix4x4 *relativeMatrix )
+void USAcquisitionObject::GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform, int relativeToObjectID )
 {
     Q_ASSERT_X(itkOutputImage, "USAcquisitionObject::GetItkImage()", "itkOutputImage must be allocated before this call");
 
-    int currentFrame = m_videoBuffer->GetCurrentFrame();
-    vtkImageData * initialImage = m_videoBuffer->GetImage( frameNo );
-
-    double org[3], st[3];
-    initialImage->GetOrigin(org);
-    initialImage->GetSpacing(st);
+    // prepare transform
     vtkSmartPointer<vtkMatrix4x4> frameMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
     frameMatrix->Identity();
     vtkSmartPointer<vtkMatrix4x4> calibratedFrameMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
     calibratedFrameMatrix->Identity();
     vtkMatrix4x4::Multiply4x4( m_videoBuffer->GetMatrix( frameNo ), m_calibrationTransform->GetMatrix(), calibratedFrameMatrix );
-    if( relativeMatrix )
+
+    vtkMatrix4x4 *relativeToMatrix = 0;
+    if( relativeToObjectID  != SceneManager::InvalidId )
+    {
+        SceneObject *relativeTo = this->GetManager()->GetObjectByID( relativeToObjectID );
+        Q_ASSERT( relativeTo );
+        relativeToMatrix = relativeTo->GetWorldTransform()->GetLinearInverse()->GetMatrix();
+    }
+
+    if( relativeToMatrix )
     {
         if( useCalibratedTransform )
         {
-            vtkMatrix4x4::Multiply4x4( relativeMatrix, calibratedFrameMatrix, frameMatrix );
+            vtkMatrix4x4::Multiply4x4( relativeToMatrix, calibratedFrameMatrix, frameMatrix );
         }
         else
-            vtkMatrix4x4::Multiply4x4( relativeMatrix, m_videoBuffer->GetMatrix( frameNo ), frameMatrix );
+            vtkMatrix4x4::Multiply4x4( relativeToMatrix, m_videoBuffer->GetMatrix( frameNo ), frameMatrix );
     }
     else
     {
@@ -812,9 +816,12 @@ bool USAcquisitionObject::GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itk
         else
             frameMatrix->DeepCopy( m_videoBuffer->GetMatrix( frameNo ) );
     }
+
+    //prepare image
+    vtkImageData * initialImage = m_videoBuffer->GetImage( frameNo );
     int numberOfScalarComponents = initialImage->GetNumberOfScalarComponents();
     vtkImageData *grayImage = initialImage;
-    vtkImageLuminance *luminanceFilter = vtkImageLuminance::New();
+    vtkSmartPointer<vtkImageLuminance> luminanceFilter = vtkSmartPointer<vtkImageLuminance>::New();
     if (numberOfScalarComponents > 1)
     {
         luminanceFilter->SetInputData(initialImage);
@@ -822,7 +829,7 @@ bool USAcquisitionObject::GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itk
         grayImage = luminanceFilter->GetOutput();
     }
     vtkImageData * image;
-    vtkImageShiftScale *shifter = vtkImageShiftScale::New();
+    vtkSmartPointer<vtkImageShiftScale> shifter = vtkSmartPointer<vtkImageShiftScale>::New();
     if (initialImage->GetScalarType() != VTK_UNSIGNED_CHAR)
     {
         shifter->SetOutputScalarType(VTK_UNSIGNED_CHAR);
@@ -836,92 +843,49 @@ bool USAcquisitionObject::GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itk
     else
         image = initialImage;
 
-    image->GetOrigin(org);
-    image->GetSpacing(st);
-    int * dimensions = initialImage->GetDimensions();
-    IbisItkUnsignedChar3ImageType::SizeType  size;
-    IbisItkUnsignedChar3ImageType::IndexType start;
-    IbisItkUnsignedChar3ImageType::RegionType region;
-    const long unsigned int numberOfPixels =  dimensions[0] * dimensions[1] * dimensions[2];
-    double imageOrigin[3];
-    image->GetOrigin(imageOrigin);
-    for (int i = 0; i < 3; i++)
-    {
-        size[i] = dimensions[i];
-    }
-
-    start.Fill(0);
-    region.SetIndex( start );
-    region.SetSize( size );
-    itkOutputImage->SetRegions(region);
-
-    itk::Matrix< double, 3,3 > dirCosine;
-    itk::Vector< double, 3 > origin;
-    itk::Vector< double, 3 > itkOrigin;
-    // set direction cosines
-    vtkMatrix4x4 * tmpMat = vtkMatrix4x4::New();
-    vtkMatrix4x4::Transpose( frameMatrix, tmpMat );
-    double step[3], mincStartPoint[3], dirCos[3][3];
-    for( int i = 0; i < 3; i++ )
-    {
-        step[i] = vtkMath::Dot( (*tmpMat)[i], (*tmpMat)[i] );
-        step[i] = sqrt( step[i] );
-        for( int j = 0; j < 3; j++ )
-        {
-            dirCos[i][j] = (*tmpMat)[i][j] / step[i];
-            dirCosine[j][i] = dirCos[i][j];
-        }
-    }
-
-    double rotation[3][3];
-    vtkMath::Transpose3x3( dirCos, rotation );
-    vtkMath::LinearSolve3x3( rotation, (*tmpMat)[3], mincStartPoint );
-
-    for( int i = 0; i < 3; i++ )
-        origin[i] =  mincStartPoint[i];
-    itkOrigin = dirCosine * origin;
-    itkOutputImage->SetSpacing(step);
-    itkOutputImage->SetOrigin(itkOrigin);
-    itkOutputImage->SetDirection(dirCosine);
-    itkOutputImage->Allocate();
-    unsigned char *itkImageBuffer = itkOutputImage->GetBufferPointer();
+    vtkSmartPointer<vtkImageStencil> sliceStencil = vtkSmartPointer<vtkImageStencil>::New();
+    vtkImageData * imageToConvert = image;
     if( masked )
     {
-        vtkSmartPointer<vtkImageStencil> sliceStencil = vtkSmartPointer<vtkImageStencil>::New();
         sliceStencil->SetStencilData( m_imageStencilSource->GetOutput() );
         sliceStencil->SetInputData( image );
         sliceStencil->SetBackgroundColor( 1.0, 1.0, 1.0, 0.0 );
         sliceStencil->Update();
-        memcpy(itkImageBuffer, sliceStencil->GetOutput()->GetScalarPointer(), numberOfPixels*sizeof(unsigned char));
+        imageToConvert = sliceStencil->GetOutput();
     }
-    else
-        memcpy(itkImageBuffer, image->GetScalarPointer(), numberOfPixels*sizeof(unsigned char));
-    tmpMat->Delete();
-    shifter->Delete();
-    luminanceFilter->Delete();
-    return true;
+
+    //convert to ITK image
+    IbisItkVtkConverter *converter = IbisItkVtkConverter::New();
+    converter->ConvertVtkImageToItkImage( itkOutputImage, imageToConvert, frameMatrix );
 }
 
 // GetItkRGBImage is used only to convert captured video frames to itk images that will be then exported using itk image writer
 // we export only uncalibrated matrices
-void USAcquisitionObject:: GetItkRGBImage(IbisRGBImageType::Pointer itkOutputImage, int frameNo, bool masked , bool useCalibratedTransform, vtkMatrix4x4* relativeMatrix )
+void USAcquisitionObject:: GetItkRGBImage(IbisRGBImageType::Pointer itkOutputImage, int frameNo, bool masked , bool useCalibratedTransform, int relativeToObjectID )
 {
     Q_ASSERT_X(itkOutputImage, "USAcquisitionObject::GetItkImage()", "itkOutputImage must be allocated before this call");
 
-    vtkImageData * image = m_videoBuffer->GetImage( frameNo );
+    // prepare transform
     vtkSmartPointer<vtkMatrix4x4> frameMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
     frameMatrix->Identity();
     vtkSmartPointer<vtkMatrix4x4> calibratedFrameMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
     calibratedFrameMatrix->Identity();
     vtkMatrix4x4::Multiply4x4( m_videoBuffer->GetMatrix( frameNo ), m_calibrationTransform->GetMatrix(), calibratedFrameMatrix );
-    if( relativeMatrix )
+    vtkMatrix4x4 *relativeToMatrix = 0;
+    if( relativeToObjectID  != SceneManager::InvalidId )
+    {
+        SceneObject *relativeTo = this->GetManager()->GetObjectByID( relativeToObjectID );
+        Q_ASSERT( relativeTo );
+        relativeToMatrix = relativeTo->GetWorldTransform()->GetLinearInverse()->GetMatrix();
+    }
+    if( relativeToMatrix )
     {
         if( useCalibratedTransform )
         {
-            vtkMatrix4x4::Multiply4x4( relativeMatrix, calibratedFrameMatrix, frameMatrix );
+            vtkMatrix4x4::Multiply4x4( relativeToMatrix, calibratedFrameMatrix, frameMatrix );
         }
         else
-            vtkMatrix4x4::Multiply4x4( relativeMatrix, m_videoBuffer->GetMatrix( frameNo ), frameMatrix );
+            vtkMatrix4x4::Multiply4x4( relativeToMatrix, m_videoBuffer->GetMatrix( frameNo ), frameMatrix );
     }
     else
     {
@@ -933,87 +897,25 @@ void USAcquisitionObject:: GetItkRGBImage(IbisRGBImageType::Pointer itkOutputIma
             frameMatrix->DeepCopy( m_videoBuffer->GetMatrix( frameNo ) );
     }
 
-    int numberOfScalarComponents = image->GetNumberOfScalarComponents();
-
-    int * dimensions = image->GetDimensions();
-    IbisItkFloat3ImageType::SizeType  size;
-    IbisItkFloat3ImageType::IndexType start;
-    IbisItkFloat3ImageType::RegionType region;
-    const long unsigned int numberOfPixels =  dimensions[0] * dimensions[1] * dimensions[2];
-    for (int i = 0; i < 3; i++)
-    {
-        size[i] = dimensions[i];
-    }
-
-    start.Fill(0);
-    region.SetIndex( start );
-    region.SetSize( size );
-    itkOutputImage->SetRegions(region);
-
-    itk::Matrix< double, 3,3 > dirCosine;
-    itk::Vector< double, 3 > origin;
-    itk::Vector< double, 3 > itkOrigin;
-    // set direction cosines
-    vtkMatrix4x4 * tmpMat = vtkMatrix4x4::New();
-    vtkMatrix4x4::Transpose( frameMatrix, tmpMat );
-    double step[3], mincStartPoint[3], dirCos[3][3];
-    for( int i = 0; i < 3; i++ )
-    {
-        step[i] = vtkMath::Dot( (*tmpMat)[i], (*tmpMat)[i] );
-        step[i] = sqrt( step[i] );
-        for( int j = 0; j < 3; j++ )
-        {
-            dirCos[i][j] = (*tmpMat)[i][j] / step[i];
-            dirCosine[j][i] = dirCos[i][j];
-        }
-    }
-
-    double rotation[3][3];
-    vtkMath::Transpose3x3( dirCos, rotation );
-    vtkMath::LinearSolve3x3( rotation, (*tmpMat)[3], mincStartPoint );
-
-    for( int i = 0; i < 3; i++ )
-        origin[i] =  mincStartPoint[i];
-    itkOrigin = dirCosine * origin;
-    itkOutputImage->SetSpacing(step);
-    itkOutputImage->SetOrigin(itkOrigin);
-    itkOutputImage->SetDirection(dirCosine);
-
-    itkOutputImage->Allocate();
-    RGBPixelType *itkImageBuffer = itkOutputImage->GetBufferPointer();
+    //prepare image
+    vtkImageData * image = m_videoBuffer->GetImage( frameNo );
+    vtkSmartPointer<vtkImageStencil> sliceStencil = vtkSmartPointer<vtkImageStencil>::New();
+    vtkImageData * imageToConvert = image;
     if( masked )
     {
-        vtkSmartPointer<vtkImageStencil> sliceStencil = vtkSmartPointer<vtkImageStencil>::New();
         sliceStencil->SetStencilData( m_imageStencilSource->GetOutput() );
         sliceStencil->SetInputData( image );
         sliceStencil->SetBackgroundColor( 1.0, 1.0, 1.0, 0.0 );
         sliceStencil->Update();
-        memcpy(itkImageBuffer, sliceStencil->GetOutput()->GetScalarPointer(), numberOfPixels*sizeof(RGBPixelType));
+        imageToConvert = sliceStencil->GetOutput();
     }
-    else
-        memcpy(itkImageBuffer, image->GetScalarPointer(), numberOfPixels*sizeof(RGBPixelType));
+
+    //convert to ITK image
+    IbisItkVtkConverter *converter = IbisItkVtkConverter::New();
+    converter->ConvertVtkImageToItkImage( itkOutputImage, imageToConvert, frameMatrix );
 }
 
 #include <itkImageFileWriter.h>
-
-void USAcquisitionObject::ConvertVtkImagesToItkRGBImages(bool masked, bool useCalibratedTransform, int relativeToID )
-{
-    m_itkRGBImages.clear();
-    int numberOfFrames = m_videoBuffer->GetNumberOfFrames();
-    for( int i = 0; i < numberOfFrames; i++ )
-    {
-        IbisRGBImageType::Pointer itkOutputImage = IbisRGBImageType::New();
-        if( relativeToID  != SceneManager::InvalidId )
-        {
-            SceneObject *relativeTo = this->GetManager()->GetObjectByID( relativeToID );
-            Q_ASSERT( relativeTo );
-            this->GetItkRGBImage( itkOutputImage, i, masked, useCalibratedTransform, relativeTo->GetWorldTransform()->GetLinearInverse()->GetMatrix() );
-        }
-        else
-            this->GetItkRGBImage( itkOutputImage, i, masked, useCalibratedTransform );
-        m_itkRGBImages.push_back( itkOutputImage );
-    }
-}
 
 void USAcquisitionObject::Export()
 {
@@ -1095,13 +997,6 @@ void USAcquisitionObject::ExportTrackedVideoBuffer(QString destDir , bool masked
         int nbComp = m_videoBuffer->GetFrameNumberOfComponents();
         if( nbComp == 1 )
         {
-            vtkMatrix4x4 *relativeToMatrix = 0;
-            if( relativeToID  != SceneManager::InvalidId )
-            {
-                SceneObject *relativeTo = this->GetManager()->GetObjectByID( relativeToID );
-                Q_ASSERT( relativeTo );
-                relativeToMatrix = relativeTo->GetWorldTransform()->GetLinearInverse()->GetMatrix();
-            }
             itk::ImageFileWriter< IbisItkUnsignedChar3ImageType >::Pointer mincWriter = itk::ImageFileWriter<IbisItkUnsignedChar3ImageType>::New();
             for( int i = 0; i < numberOfFrames && processOK; i++ )
             {
@@ -1118,16 +1013,9 @@ void USAcquisitionObject::ExportTrackedVideoBuffer(QString destDir , bool masked
                 numberedFileName += ".mnc";
                 mincWriter->SetFileName(numberedFileName.toUtf8().data());
 
-                IbisItkUnsignedChar3ImageType::Pointer itkSliceImage;
-
-                itkSliceImage = IbisItkUnsignedChar3ImageType::New();
-                if ( !this->GetItkImage(itkSliceImage, i,  masked,  useCalibratedTransform, relativeToMatrix ) )
-                {
-                    processOK = false;
-                    break;
-                 }
+                IbisItkUnsignedChar3ImageType::Pointer itkSliceImage = IbisItkUnsignedChar3ImageType::New();
+                this->GetItkImage(itkSliceImage, i,  masked,  useCalibratedTransform, relativeToID );
                 mincWriter->SetInput( itkSliceImage );
-
                 try
                 {
                     mincWriter->Update();
@@ -1150,7 +1038,6 @@ void USAcquisitionObject::ExportTrackedVideoBuffer(QString destDir , bool masked
         }
         else
         {
-            this->ConvertVtkImagesToItkRGBImages( masked, useCalibratedTransform, relativeToID );
             itk::ImageFileWriter< IbisRGBImageType >::Pointer mincWriter = itk::ImageFileWriter<IbisRGBImageType>::New();
             for( int i = 0; i < numberOfFrames && processOK; i++ )
             {
@@ -1167,7 +1054,9 @@ void USAcquisitionObject::ExportTrackedVideoBuffer(QString destDir , bool masked
                 numberedFileName += ".mnc";
                 mincWriter->SetFileName(numberedFileName.toUtf8().data());
 
-                mincWriter->SetInput( m_itkRGBImages[i] );
+                IbisRGBImageType::Pointer itkSliceImage = IbisRGBImageType::New();
+                this->GetItkRGBImage(itkSliceImage, i,  masked,  useCalibratedTransform, relativeToID );
+                mincWriter->SetInput( itkSliceImage );
 
                 try
                 {

--- a/IbisLib/usacquisitionobject.cpp
+++ b/IbisLib/usacquisitionobject.cpp
@@ -770,7 +770,7 @@ vtkImageData * USAcquisitionObject::GetMask()
 // GetItkImage in release 2.3.1 is used only in GPU Volume Reconstruction and is not meant for general application
 // It uses calibrated slice matrix
 // We should write a special function converting vtk to itk image
-bool USAcquisitionObject::GetItkImage(IbisItk3DImageType::Pointer itkOutputImage, int frameNo,
+bool USAcquisitionObject::GetItkImage(IbisItkFloat3ImageType::Pointer itkOutputImage, int frameNo,
      vtkMatrix4x4 * sliceMatrix)
 {
     Q_ASSERT_X(itkOutputImage, "USAcquisitionObject::GetItkImage()", "itkOutputImage must be allocated before this call");
@@ -812,9 +812,9 @@ bool USAcquisitionObject::GetItkImage(IbisItk3DImageType::Pointer itkOutputImage
     image->GetOrigin(org);
     image->GetSpacing(st);
     int * dimensions = initialImage->GetDimensions();
-    IbisItk3DImageType::SizeType  size;
-    IbisItk3DImageType::IndexType start;
-    IbisItk3DImageType::RegionType region;
+    IbisItkFloat3ImageType::SizeType  size;
+    IbisItkFloat3ImageType::IndexType start;
+    IbisItkFloat3ImageType::RegionType region;
     const long unsigned int numberOfPixels =  dimensions[0] * dimensions[1] * dimensions[2];
     double imageOrigin[3];
     image->GetOrigin(imageOrigin);
@@ -865,7 +865,7 @@ bool USAcquisitionObject::GetItkImage(IbisItk3DImageType::Pointer itkOutputImage
     return true;
 }
 
-bool USAcquisitionObject::GetItkImage(IbisItk3DLabelType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform, vtkMatrix4x4 *relativeMatrix )
+bool USAcquisitionObject::GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform, vtkMatrix4x4 *relativeMatrix )
 {
     Q_ASSERT_X(itkOutputImage, "USAcquisitionObject::GetItkImage()", "itkOutputImage must be allocated before this call");
 
@@ -925,9 +925,9 @@ bool USAcquisitionObject::GetItkImage(IbisItk3DLabelType::Pointer itkOutputImage
     image->GetOrigin(org);
     image->GetSpacing(st);
     int * dimensions = initialImage->GetDimensions();
-    IbisItk3DLabelType::SizeType  size;
-    IbisItk3DLabelType::IndexType start;
-    IbisItk3DLabelType::RegionType region;
+    IbisItkUnsignedChar3ImageType::SizeType  size;
+    IbisItkUnsignedChar3ImageType::IndexType start;
+    IbisItkUnsignedChar3ImageType::RegionType region;
     const long unsigned int numberOfPixels =  dimensions[0] * dimensions[1] * dimensions[2];
     double imageOrigin[3];
     image->GetOrigin(imageOrigin);
@@ -1022,9 +1022,9 @@ void USAcquisitionObject:: GetItkRGBImage(IbisRGBImageType::Pointer itkOutputIma
     int numberOfScalarComponents = image->GetNumberOfScalarComponents();
 
     int * dimensions = image->GetDimensions();
-    IbisItk3DImageType::SizeType  size;
-    IbisItk3DImageType::IndexType start;
-    IbisItk3DImageType::RegionType region;
+    IbisItkFloat3ImageType::SizeType  size;
+    IbisItkFloat3ImageType::IndexType start;
+    IbisItkFloat3ImageType::RegionType region;
     const long unsigned int numberOfPixels =  dimensions[0] * dimensions[1] * dimensions[2];
     for (int i = 0; i < 3; i++)
     {
@@ -1188,7 +1188,7 @@ void USAcquisitionObject::ExportTrackedVideoBuffer(QString destDir , bool masked
                 Q_ASSERT( relativeTo );
                 relativeToMatrix = relativeTo->GetWorldTransform()->GetLinearInverse()->GetMatrix();
             }
-            itk::ImageFileWriter< IbisItk3DLabelType >::Pointer mincWriter = itk::ImageFileWriter<IbisItk3DLabelType>::New();
+            itk::ImageFileWriter< IbisItkUnsignedChar3ImageType >::Pointer mincWriter = itk::ImageFileWriter<IbisItkUnsignedChar3ImageType>::New();
             for( int i = 0; i < numberOfFrames && processOK; i++ )
             {
                 QString Number( QString::number( ++sequenceNumber ));
@@ -1204,9 +1204,9 @@ void USAcquisitionObject::ExportTrackedVideoBuffer(QString destDir , bool masked
                 numberedFileName += ".mnc";
                 mincWriter->SetFileName(numberedFileName.toUtf8().data());
 
-                IbisItk3DLabelType::Pointer itkSliceImage;
+                IbisItkUnsignedChar3ImageType::Pointer itkSliceImage;
 
-                itkSliceImage = IbisItk3DLabelType::New();
+                itkSliceImage = IbisItkUnsignedChar3ImageType::New();
                 if ( !this->GetItkImage(itkSliceImage, i,  masked,  useCalibratedTransform, relativeToMatrix ) )
                 {
                     processOK = false;

--- a/IbisLib/usacquisitionobject.h
+++ b/IbisLib/usacquisitionobject.h
@@ -38,8 +38,6 @@ class USMask;
 class vtkImageConstantPad;
 class vtkPassThrough;
 
-typedef itk::Image<float,3> IbisItkFloat3ImageType;
-
 #define ACQ_COLOR_RGB           "RGB"
 #define ACQ_COLOR_GRAYSCALE     "Grayscale"
 #define ACQ_BASE_DIR            "acquisitions"

--- a/IbisLib/usacquisitionobject.h
+++ b/IbisLib/usacquisitionobject.h
@@ -38,7 +38,7 @@ class USMask;
 class vtkImageConstantPad;
 class vtkPassThrough;
 
-typedef itk::Image<float,3> IbisItk3DImageType;
+typedef itk::Image<float,3> IbisItkFloat3ImageType;
 
 #define ACQ_COLOR_RGB           "RGB"
 #define ACQ_COLOR_GRAYSCALE     "Grayscale"
@@ -97,8 +97,8 @@ public:
     void SetFrameAndMaskSize( int width, int height );
 
     // Return itk image of a given frame
-    bool GetItkImage(IbisItk3DImageType::Pointer itkOutputImage, int frameNo, vtkMatrix4x4* sliceMatrix);
-    bool GetItkImage(IbisItk3DLabelType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, vtkMatrix4x4 *relativeMatrix = 0  );
+    bool GetItkImage(IbisItkFloat3ImageType::Pointer itkOutputImage, int frameNo, vtkMatrix4x4* sliceMatrix);
+    bool GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, vtkMatrix4x4 *relativeMatrix = 0  );
     void GetItkRGBImage(IbisRGBImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, vtkMatrix4x4 *relativeMatrix = 0 );
 
     // Display of current slice

--- a/IbisLib/usacquisitionobject.h
+++ b/IbisLib/usacquisitionobject.h
@@ -96,8 +96,10 @@ public:
 
     void SetFrameAndMaskSize( int width, int height );
 
+    // Return frame data
+    void GetFrameData(int index, vtkImageData *img, vtkMatrix4x4 *mat );
+
     // Return itk image of a given frame
-    bool GetItkImage(IbisItkFloat3ImageType::Pointer itkOutputImage, int frameNo, vtkMatrix4x4* sliceMatrix);
     bool GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, vtkMatrix4x4 *relativeMatrix = 0  );
     void GetItkRGBImage(IbisRGBImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, vtkMatrix4x4 *relativeMatrix = 0 );
 

--- a/IbisLib/usacquisitionobject.h
+++ b/IbisLib/usacquisitionobject.h
@@ -100,8 +100,8 @@ public:
     void GetFrameData(int index, vtkImageData *img, vtkMatrix4x4 *mat );
 
     // Return itk image of a given frame
-    bool GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, vtkMatrix4x4 *relativeMatrix = 0  );
-    void GetItkRGBImage(IbisRGBImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, vtkMatrix4x4 *relativeMatrix = 0 );
+    void GetItkImage(IbisItkUnsignedChar3ImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, int relativeToObjectID = SceneManager::InvalidId );
+    void GetItkRGBImage(IbisRGBImageType::Pointer itkOutputImage, int frameNo, bool masked, bool useCalibratedTransform = false, int relativeToObjectID = SceneManager::InvalidId );
 
     // Display of current slice
     int GetSliceWidth();
@@ -222,10 +222,7 @@ protected:
     std::vector< PerStaticSlice > m_staticSlicesData;
     bool m_staticSlicesDataNeedUpdate;
 
-    std::vector< IbisRGBImageType::Pointer > m_itkRGBImages;
-
     void Save( );
-    void ConvertVtkImagesToItkRGBImages(bool masked = false, bool useCalibratedTransform = false, int relativeToID = SceneManager::InvalidId );
 };
 
 ObjectSerializationHeaderMacro( USAcquisitionObject );

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
@@ -193,8 +193,8 @@ void GPU_RigidRegistrationWidget::on_startButton_clicked()
     Q_ASSERT_X( targetImageObject, "GPU_RigidRegistrationWidget::on_startButton_clicked()", "Invalid target object" );
     vtkTransform * targetVtkTransform = vtkTransform::SafeDownCast( targetImageObject->GetWorldTransform() );
 
-    IbisItk3DImageType::Pointer itkSourceImage = sourceImageObject->GetItkImage();
-    IbisItk3DImageType::Pointer itkTargetImage = targetImageObject->GetItkImage();
+    IbisItkFloat3ImageType::Pointer itkSourceImage = sourceImageObject->GetItkImage();
+    IbisItkFloat3ImageType::Pointer itkTargetImage = targetImageObject->GetItkImage();
 
 
     QElapsedTimer timer;

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.h
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.h
@@ -32,11 +32,11 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "itkSPSAOptimizer.h"
 #include "itkCMAEvolutionStrategyOptimizer.h"
 
-typedef itk::ImageDuplicator< IbisItk3DImageType >  DuplicatorType;
+typedef itk::ImageDuplicator< IbisItkFloat3ImageType >  DuplicatorType;
 
 typedef itk::CMAEvolutionStrategyOptimizer            OptimizerType;
 
-typedef itk::GPU3DRigidSimilarityMetric<IbisItk3DImageType,IbisItk3DImageType>
+typedef itk::GPU3DRigidSimilarityMetric<IbisItkFloat3ImageType,IbisItkFloat3ImageType>
                                                     GPUCostFunctionType;
 typedef GPUCostFunctionType::Pointer                GPUCostFunctionPointer;
 

--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
@@ -159,6 +159,7 @@ void GPU_VolumeReconstructionWidget::slot_finished()
 }
 
 
+#include "ibisitkvtkconverter.h"
 void GPU_VolumeReconstructionWidget::on_startButton_clicked()
 {
     // Make sure all params have been specified
@@ -223,12 +224,14 @@ void GPU_VolumeReconstructionWidget::on_startButton_clicked()
 
     IbisItkFloat3ImageType::Pointer itkSliceImage[nbrOfSlices];
 
-    vtkSmartPointer<vtkMatrix4x4> sliceTransformMatrix[nbrOfSlices];
+    vtkSmartPointer<vtkMatrix4x4> sliceTransformMatrix = vtkSmartPointer<vtkMatrix4x4>::New() ;
+    vtkSmartPointer<vtkImageData> slice = vtkSmartPointer<vtkImageData>::New();
+    vtkSmartPointer<IbisItkVtkConverter> converter = vtkSmartPointer<IbisItkVtkConverter>::New();
     for(unsigned int i=0; i<nbrOfSlices; i++)
     {
       itkSliceImage[i] = IbisItkFloat3ImageType::New();
-      sliceTransformMatrix[i] = vtkSmartPointer<vtkMatrix4x4>::New();
-      if ( selectedUSAcquisitionObject->GetItkImage(itkSliceImage[i], i, sliceTransformMatrix[i].GetPointer()) )
+      selectedUSAcquisitionObject->GetFrameData( i, slice.GetPointer(), sliceTransformMatrix.GetPointer() );
+      if( converter->ConvertVtkImageToItkImage( itkSliceImage[i], slice, sliceTransformMatrix ) )
         m_Reconstructor->SetFixedSlice(i, itkSliceImage[i]);
     }
 

--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
@@ -47,7 +47,7 @@ void GPU_VolumeReconstructionWidget::SetApplication( Application * app )
     UpdateUi();
 }
 
-void GPU_VolumeReconstructionWidget::VtkToItkImage( vtkImageData * vtkInputImage, IbisItk3DImageType * itkOutputImage, vtkSmartPointer<vtkMatrix4x4> transformMatrix )
+void GPU_VolumeReconstructionWidget::VtkToItkImage( vtkImageData * vtkInputImage, IbisItkFloat3ImageType * itkOutputImage, vtkSmartPointer<vtkMatrix4x4> transformMatrix )
 {
   int numberOfScalarComponents = vtkInputImage->GetNumberOfScalarComponents();
   vtkImageData *grayImage = vtkInputImage;
@@ -74,9 +74,9 @@ void GPU_VolumeReconstructionWidget::VtkToItkImage( vtkImageData * vtkInputImage
       image = vtkInputImage;  
 
   int * dimensions = vtkInputImage->GetDimensions();
-  IbisItk3DImageType::SizeType  size;
-  IbisItk3DImageType::IndexType start;
-  IbisItk3DImageType::RegionType region;
+  IbisItkFloat3ImageType::SizeType  size;
+  IbisItkFloat3ImageType::IndexType start;
+  IbisItkFloat3ImageType::RegionType region;
   const long unsigned int numberOfPixels =  dimensions[0] * dimensions[1] * dimensions[2];
   double imageOrigin[3];
   image->GetOrigin(imageOrigin);
@@ -203,7 +203,7 @@ void GPU_VolumeReconstructionWidget::on_startButton_clicked()
     std::cerr << "US Acquisition Object with " << nbrOfSlices << " slices." << std::endl;
 #endif    
 
-    IbisItk3DImageType::Pointer itkSliceMask = IbisItk3DImageType::New();
+    IbisItkFloat3ImageType::Pointer itkSliceMask = IbisItkFloat3ImageType::New();
     vtkSmartPointer<vtkMatrix4x4> sliceMaskMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
     this->VtkToItkImage( selectedUSAcquisitionObject->GetMask(), itkSliceMask, sliceMaskMatrix  );
 
@@ -221,12 +221,12 @@ void GPU_VolumeReconstructionWidget::on_startButton_clicked()
     std::cerr << "Constructing m_Reconstructor...DONE" << std::endl;
 #endif
 
-    IbisItk3DImageType::Pointer itkSliceImage[nbrOfSlices];
+    IbisItkFloat3ImageType::Pointer itkSliceImage[nbrOfSlices];
 
     vtkSmartPointer<vtkMatrix4x4> sliceTransformMatrix[nbrOfSlices];
     for(unsigned int i=0; i<nbrOfSlices; i++)
     {
-      itkSliceImage[i] = IbisItk3DImageType::New();
+      itkSliceImage[i] = IbisItkFloat3ImageType::New();
       sliceTransformMatrix[i] = vtkSmartPointer<vtkMatrix4x4>::New();
       if ( selectedUSAcquisitionObject->GetItkImage(itkSliceImage[i], i, sliceTransformMatrix[i].GetPointer()) )
         m_Reconstructor->SetFixedSlice(i, itkSliceImage[i]);

--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.h
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.h
@@ -35,7 +35,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "itkGPUVolumeReconstruction.h"
 #include "itkEuler3DTransform.h"
 
-typedef itk::GPUVolumeReconstruction<IbisItk3DImageType>
+typedef itk::GPUVolumeReconstruction<IbisItkFloat3ImageType>
                                                     VolumeReconstructionType;
 typedef VolumeReconstructionType::Pointer           VolumeReconstructionPointer;
 
@@ -64,7 +64,7 @@ public:
 private:
 
     void UpdateUi();
-    void VtkToItkImage( vtkImageData * vtkImage, IbisItk3DImageType * itkOutputImage, vtkSmartPointer<vtkMatrix4x4> transformMatrix );
+    void VtkToItkImage( vtkImageData * vtkImage, IbisItkFloat3ImageType * itkOutputImage, vtkSmartPointer<vtkMatrix4x4> transformMatrix );
 
     Ui::GPU_VolumeReconstructionWidget * ui;
     Application * m_application;

--- a/IbisPlugins/ImageFilterExample/imagefilterexamplewidget.cpp
+++ b/IbisPlugins/ImageFilterExample/imagefilterexamplewidget.cpp
@@ -62,8 +62,8 @@ void ImageFilterExampleWidget::on_startButton_clicked()
     ImageObject * targetImageObject = ImageObject::SafeDownCast( sm->GetObjectByID( targetImageObjectId ) );
     Q_ASSERT_X( targetImageObject, "ImageFilterExampleWidget::on_startButton_clicked()", "Invalid target object" );
 
-    IbisItk3DImageType::Pointer itkSourceImage = sourceImageObject->GetItkImage();
-    IbisItk3DImageType::Pointer itkTargetImage = targetImageObject->GetItkImage();
+    IbisItkFloat3ImageType::Pointer itkSourceImage = sourceImageObject->GetItkImage();
+    IbisItkFloat3ImageType::Pointer itkTargetImage = targetImageObject->GetItkImage();
 
     //====================================================================================
     // -----------------------     TODO    ---------------------------------------


### PR DESCRIPTION
Existing conversion code moved from ImageObject and USAcquisitionObject to a new class IbisItkVtkConverter. Code revised and simplified. ITK image types renamed: IbisItk3DImageType becomes IbisItkFloat3ImageType,  IbisItk3DLabelType becomes IbisItkUnsignedChar3ImageType. The last one is used  for labels and grayscale acquisition frames.
