### PR TITLE
Fixed removing LandmarkRegistrationObject.

### DIFF
--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -451,6 +451,7 @@ void SceneManager::Serialize( Serializer * ser )
                 ::Serialize( ser, viewName.toUtf8().data(), view );
             }
         }
+        ser->EndSection();
         return;
     }
     // writer

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -177,6 +177,9 @@ void LandmarkRegistrationObject::ObjectAddedToScene()
 
 void LandmarkRegistrationObject::ObjectAboutToBeRemovedFromScene()
 {
+    // m_targetPoints is not a child of LandmarkRegistrationObject, it has to be removed explicitly
+    if( m_targetPoints )
+        GetManager()->RemoveObject( m_targetPoints );
     disconnect( GetManager(), SIGNAL(CurrentObjectChanged()), this, SLOT(CurrentObjectChanged()));
 }
 


### PR DESCRIPTION
Put back the code removing target points in LandmarkRegistrationObject::ObjectAboutToBeRemovedFromScene()