### PR TITLE
2D  alignment  issue #2

### DIFF
--- a/IbisLib/gui/transformeditwidget.cpp
+++ b/IbisLib/gui/transformeditwidget.cpp
@@ -208,7 +208,7 @@ void TransformEditWidget::SetIdentityButtonClicked()
         if( transform )
         {
             transform->Identity();
-            transform->Modified();
+            transform->Modified(); // this patch is added to correct vtk bug in vtkTransform::Identity() and will be removed once vtk is fixed.
             this->UpdateUi();
         }
     }

--- a/IbisLib/gui/transformeditwidget.cpp
+++ b/IbisLib/gui/transformeditwidget.cpp
@@ -208,6 +208,7 @@ void TransformEditWidget::SetIdentityButtonClicked()
         if( transform )
         {
             transform->Identity();
+            transform->Modified();
             this->UpdateUi();
         }
     }

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -82,13 +82,6 @@ SceneManager::~SceneManager()
     this->SceneRoot->Delete();
 }
 
-// for debugging only
-int SceneManager::GetRefCount()
-{
-    int n = this->GetReferenceCount();
-    return n;
-}
-
 void SceneManager::Destroy()
 {
     this->ReleaseAllViews();

--- a/IbisLib/scenemanager.h
+++ b/IbisLib/scenemanager.h
@@ -290,8 +290,6 @@ public:
     // Description
     // Utility functions
     static QString FindUniqueName( QString wantedName, QStringList & otherNames );
-    // for debugging only
-    int GetRefCount();
 
     // navigation
     void EnablePointerNavigation( bool on);

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -520,6 +520,24 @@ void View::ReferenceTransformChanged()
     // We update transform only if it is a 2D view or if Manager says we follow 3D views as well
     if( this->Manager && ( this->GetType() != THREED_VIEW_TYPE || this->Manager->Is3DViewFollowingReferenceVolume() ) )
     {
+        this->ApplyReferenceTransform();
+        NotifyNeedRender();
+    }
+}
+
+void View::WindowStartsRendering()
+{
+    if( this->GetType() != THREED_VIEW_TYPE )
+    {
+        this->ApplyReferenceTransform();
+    }
+    this->Renderer->ResetCameraClippingRange();
+}
+
+void View::ApplyReferenceTransform()
+{
+    if( this->Manager )
+    {
         ImageObject * obj = this->Manager->GetReferenceDataObject();
         if( obj && this->Renderer )
         {
@@ -536,15 +554,8 @@ void View::ReferenceTransformChanged()
             // backup inverted current transform
             this->PrevViewingTransform->DeepCopy( refTransform->GetMatrix() );
             this->PrevViewingTransform->Invert();
-
-            NotifyNeedRender();
         }
     }
-}
-
-void View::WindowStartsRendering()
-{
-    this->Renderer->ResetCameraClippingRange();
 }
 
 void View::SetupAllObjects()

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -520,24 +520,6 @@ void View::ReferenceTransformChanged()
     // We update transform only if it is a 2D view or if Manager says we follow 3D views as well
     if( this->Manager && ( this->GetType() != THREED_VIEW_TYPE || this->Manager->Is3DViewFollowingReferenceVolume() ) )
     {
-        this->ApplyReferenceTransform();
-        NotifyNeedRender();
-    }
-}
-
-void View::WindowStartsRendering()
-{
-    if( this->GetType() != THREED_VIEW_TYPE )
-    {
-        this->ApplyReferenceTransform();
-    }
-    this->Renderer->ResetCameraClippingRange();
-}
-
-void View::ApplyReferenceTransform()
-{
-    if( this->Manager )
-    {
         ImageObject * obj = this->Manager->GetReferenceDataObject();
         if( obj && this->Renderer )
         {
@@ -554,8 +536,15 @@ void View::ApplyReferenceTransform()
             // backup inverted current transform
             this->PrevViewingTransform->DeepCopy( refTransform->GetMatrix() );
             this->PrevViewingTransform->Invert();
+
+            NotifyNeedRender();
         }
     }
+}
+
+void View::WindowStartsRendering()
+{
+    this->Renderer->ResetCameraClippingRange();
 }
 
 void View::SetupAllObjects()

--- a/IbisLib/view.h
+++ b/IbisLib/view.h
@@ -140,7 +140,6 @@ protected:
     void ReleaseAllObjects();
     void GetPositionAndModifier( int & x, int & y, unsigned & modifier );
     void AdjustCameraDistance( double viewAngle );
-    void ApplyReferenceTransform();
 
     QString Name;
     vtkQtRenderWindow * RenderWindow;

--- a/IbisLib/view.h
+++ b/IbisLib/view.h
@@ -140,7 +140,8 @@ protected:
     void ReleaseAllObjects();
     void GetPositionAndModifier( int & x, int & y, unsigned & modifier );
     void AdjustCameraDistance( double viewAngle );
-    
+    void ApplyReferenceTransform();
+
     QString Name;
     vtkQtRenderWindow * RenderWindow;
     bool m_renderingEnabled;


### PR DESCRIPTION
I reproduced the problem using the method described by Simon - manually modify the transform of the reference object and the to press the Identity button. 
I found out that the pipeline has to be updated by emitting signal Modified() when resetting transform to Identity.