### PR TITLE
IbisHardwareIGSIO support tools params

### DIFF
--- a/IbisHardwareIGSIO/configio.cpp
+++ b/IbisHardwareIGSIO/configio.cpp
@@ -29,6 +29,8 @@ void ToolConfig::Serialize( Serializer * ser )
 {
     ::Serialize( ser, "ToolName", ToolName );
     ::Serialize( ser, "ToolType", ToolType );
+    ::Serialize( ser, "ToolModelFile", ToolModelFile);
+    ::Serialize(ser, "ToolParamFile", ToolParamFile);
 }
 
 void DeviceToolAssociation::Serialize( Serializer * ser )
@@ -96,6 +98,18 @@ QString ConfigIO::GetToolType( int index )
 {
     Q_ASSERT( index >=0 && index < m_tools.size() );
     return m_tools[index].ToolType;
+}
+
+QString ConfigIO::GetToolModelFile(int index)
+{
+    Q_ASSERT(index >= 0 && index < m_tools.size());
+    return m_tools[index].ToolModelFile;
+}
+
+QString ConfigIO::GetToolParamFile(int index)
+{
+    Q_ASSERT(index >= 0 && index < m_tools.size());
+    return m_tools[index].ToolParamFile;
 }
 
 DeviceToolMap ConfigIO::GetAssociations()

--- a/IbisHardwareIGSIO/configio.h
+++ b/IbisHardwareIGSIO/configio.h
@@ -29,6 +29,8 @@ public:
     void Serialize( Serializer * ser );
     QString ToolName;
     QString ToolType;
+    QString ToolModelFile;
+    QString ToolParamFile;
 };
 
 ObjectSerializationHeaderMacro( ToolConfig );
@@ -70,6 +72,8 @@ public:
     int GetNumberOfTools() { return m_tools.size(); }
     QString GetToolName( int index );
     QString GetToolType( int index );
+    QString GetToolModelFile(int index);
+    QString GetToolParamFile(int index);
 
     // Associations
     DeviceToolMap GetAssociations();

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -99,11 +99,11 @@ void IbisHardwareIGSIO::StartConfig( QString configFile )
         Tool * newTool = new Tool;
         newTool->sceneObject = InstanciateSceneObjectFromType( in.GetToolName(i), in.GetToolType( i ) );
         newTool->toolModel = InstanciateToolModel(in.GetToolModelFile(i));
-        if (newTool->toolModel)
-            newTool->sceneObject->AddChild(newTool->toolModel);
         ReadToolConfig( in.GetToolParamFile(i), newTool->sceneObject );
         m_tools.append( newTool );
         GetIbisAPI()->AddObject( newTool->sceneObject );
+        if (newTool->toolModel)
+            GetIbisAPI()->AddObject(newTool->toolModel, newTool->sceneObject);
     }
 
     // Keep track of Plus device to Ibis tool association
@@ -461,8 +461,7 @@ TrackedSceneObject * IbisHardwareIGSIO::InstanciateSceneObjectFromType( QString 
 vtkSmartPointer<PolyDataObject> IbisHardwareIGSIO::InstanciateToolModel( QString filename )
 {
     vtkSmartPointer<PolyDataObject> model;
-    QString configDir = GetIbisAPI()->GetConfigDirectory();
-    QString toolModelDir = configDir + "/ToolModels";
+    QString toolModelDir = m_plusConfigDirectory + "/ToolModels";
     QString modelFileName = toolModelDir + "/" + filename;
     if (QFile::exists(modelFileName))
     {

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -483,6 +483,9 @@ vtkSmartPointer<PolyDataObject> IbisHardwareIGSIO::InstanciateToolModel( QString
 
 void IbisHardwareIGSIO::ReadToolConfig(QString filename, vtkSmartPointer<TrackedSceneObject> tool)
 {
+    if (filename.isEmpty())
+        return;
+
     QString path = m_ibisPlusConfigFilesDirectory + "/" + filename;
 
     // Make sure the config file exists

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -16,6 +16,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "pointerobject.h"
 #include "usprobeobject.h"
 #include "cameraobject.h"
+#include "polydataobject.h"
 
 #include <QDir>
 #include <QMenu>
@@ -28,6 +29,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "vtkTransform.h"
 #include "vtkImageData.h"
 #include "vtkEventQtSlotConnect.h"
+#include "vtkPLYReader.h"
 
 #include "igtlioLogic.h"
 #include "igtlioTransformDevice.h"
@@ -96,6 +98,10 @@ void IbisHardwareIGSIO::StartConfig( QString configFile )
     {
         Tool * newTool = new Tool;
         newTool->sceneObject = InstanciateSceneObjectFromType( in.GetToolName(i), in.GetToolType( i ) );
+        newTool->toolModel = InstanciateToolModel(in.GetToolModelFile(i));
+        if (newTool->toolModel)
+            newTool->sceneObject->AddChild(newTool->toolModel);
+        ReadToolConfig( in.GetToolParamFile(i), newTool->sceneObject );
         m_tools.append( newTool );
         GetIbisAPI()->AddObject( newTool->sceneObject );
     }
@@ -261,6 +267,7 @@ void IbisHardwareIGSIO::OpenSettingsWidget()
         m_clientWidget->setLogic( m_logic );
         m_clientWidget->setGeometry(0,0, 859, 811);
         m_clientWidget->setAttribute( Qt::WA_DeleteOnClose );
+        m_clientWidget->setWindowFlag( Qt::WindowStaysOnTopHint, true);
         connect( m_clientWidget, SIGNAL(destroyed(QObject*)), this, SLOT(OnSettingsWidgetClosed()));
     }
 
@@ -279,6 +286,7 @@ void IbisHardwareIGSIO::OpenConfigFileWidget()
         m_settingsWidget = new IbisHardwareIGSIOSettingsWidget;
         m_settingsWidget->SetIgsio( this );
         m_settingsWidget->setAttribute( Qt::WA_DeleteOnClose );
+        m_settingsWidget->setWindowFlag(Qt::WindowStaysOnTopHint, true);
         connect( m_settingsWidget, SIGNAL(destroyed(QObject*)), this, SLOT(OnConfigFileWidgetClosed()));
     }
     m_settingsWidget->show();
@@ -448,6 +456,47 @@ TrackedSceneObject * IbisHardwareIGSIO::InstanciateSceneObjectFromType( QString 
     res->SetHardwareModule( this );
 
     return res;
+}
+
+vtkSmartPointer<PolyDataObject> IbisHardwareIGSIO::InstanciateToolModel( QString filename )
+{
+    vtkSmartPointer<PolyDataObject> model;
+    QString configDir = GetIbisAPI()->GetConfigDirectory();
+    QString toolModelDir = configDir + "/ToolModels";
+    QString modelFileName = toolModelDir + "/" + filename;
+    if (QFile::exists(modelFileName))
+    {
+        vtkPLYReader * reader = vtkPLYReader::New();
+        reader->SetFileName(modelFileName.toUtf8().data());
+        reader->Update();
+        model = vtkSmartPointer<PolyDataObject>::New();
+        model->SetNameChangeable(false);
+        model->SetCanChangeParent(false);
+        model->SetObjectManagedBySystem(true);
+        model->SetObjectManagedByTracker(true);
+        model->SetPolyData(reader->GetOutput());
+        model->SetScalarsVisible(true);
+        reader->Delete();
+        model->SetName("3D Model");
+    }
+    return model;
+}
+
+void IbisHardwareIGSIO::ReadToolConfig(QString filename, vtkSmartPointer<TrackedSceneObject> tool)
+{
+    QString path = m_ibisPlusConfigFilesDirectory + "/" + filename;
+
+    // Make sure the config file exists
+    QFileInfo info(path);
+    if (!info.exists() || !info.isReadable())
+        return;
+
+    // Read config file
+    SerializerReader reader;
+    reader.SetFilename(path.toUtf8().data());
+    reader.Start();
+    tool->Serialize(&reader);
+    reader.Finish();
 }
 
 bool IbisHardwareIGSIO::IsDeviceImage( igtlioDevicePointer device )

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.h
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.h
@@ -23,6 +23,7 @@ class qIGTLIOClientWidget;
 class PlusServerInterface;
 class vtkEventQtSlotConnect;
 class IbisHardwareIGSIOSettingsWidget;
+class PolyDataObject;
 
 class IbisHardwareIGSIO : public HardwareModule
 {
@@ -99,6 +100,8 @@ protected:
     // Utility functions
     int FindToolByName( QString name );
     TrackedSceneObject * InstanciateSceneObjectFromType( QString objectName, QString objectType );
+    vtkSmartPointer<PolyDataObject> InstanciateToolModel(QString filename);
+    void ReadToolConfig(QString filename,vtkSmartPointer<TrackedSceneObject> tool);
     bool IsDeviceImage( igtlioDevicePointer device );
     bool IsDeviceTransform( igtlioDevicePointer device );
     bool IsDeviceVideo( igtlioDevicePointer device );
@@ -106,6 +109,7 @@ protected:
     struct Tool
     {
         vtkSmartPointer<TrackedSceneObject> sceneObject;
+        vtkSmartPointer<PolyDataObject> toolModel;
         igtlioDevicePointer transformDevice;
         igtlioDevicePointer imageDevice;
     };

--- a/IbisHardwareIGSIO/ibishardwareIGSIOsettingswidget.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIOsettingswidget.cpp
@@ -50,8 +50,10 @@ void IbisHardwareIGSIOSettingsWidget::UpdateUI()
 void IbisHardwareIGSIOSettingsWidget::on_applyConfigFileButton_clicked()
 {
     QString configFileName = ui->configFileComboBox->currentText();
-    if( configFileName != "None" )
-        m_igsio->StartConfig( configFileName );
+    if (configFileName != "None")
+        m_igsio->StartConfig(configFileName);
+    else
+        m_igsio->ClearConfig();
 }
 
 void IbisHardwareIGSIOSettingsWidget::on_autoStartLastConfigCheckBox_toggled( bool checked )


### PR DESCRIPTION
* Tool params (ex. calib matrices, camera params, etc.) are now loaded from xml files in the config directory. The params are loaded using the same serialization functions as with the legacy hardware module. The main difference is that the parameters are not all in the same file but one file per tool.

* Tool 3D models can now be loaded from a filename specified in the main config file. 