### PR TITLE
Us acquisition import

### DIFF
--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -673,55 +673,6 @@ QString Application::GetExistingDirectory( const QString & caption, const QStrin
     return dirname;
 }
 
-//bool Application::GetOpenFileSequence( QStringList & filenames, QString extension, const QString & caption, const QString & dir, const QString & filter )
-//{
-//    // Get Base directory and file pattern
-//    QString firstFilename = Application::GetInstance().GetFileNameOpen( "Select first file of acquisition", dir, "Minc file (*.mnc)" );
-//    if( firstFilename.isEmpty() )
-//        return false;
-
-//    // find first digit
-//    int it = firstFilename.size() - 1;
-//    while( !firstFilename.at( it ).isDigit() && it > 0 )
-//        --it;
-//    if( it <= 0 )
-//        return false;
-
-//    int nbCharTrailer = firstFilename.size() - it - 1;
-//    QString trailer = firstFilename.right( nbCharTrailer );
-
-//    // find the number of digits
-//    int nbDigits = 0;
-//    while( firstFilename.at( it ).isDigit() && it >= 0 )
-//    {
-//        --it;
-//        nbDigits++;
-//    }
-
-//    bool ok = true;
-//    int firstNumber = firstFilename.mid( it + 1, nbDigits ).toInt( &ok );
-//    if( !ok )
-//        return false;
-
-//    QString basePath = firstFilename.left( it + 1 );
-
-//    // find the number of files
-//    bool done = false;
-//    int fileNumber = firstNumber;
-//    while( !done )
-//    {
-//        QString name = QString( basePath + "%1" + trailer ).arg( fileNumber, nbDigits, 10, QChar('0') );
-//        if( !QFile::exists( name ) )
-//            done = true;
-//        else
-//        {
-//            ++fileNumber;
-//            filenames.push_back( name );
-//        }
-//    }
-//    return true;
-//}
-
 bool Application::GetOpenFileSequence( QStringList & filenames, QString extension, const QString & caption, const QString & dir, const QString & filter )
 {
     // Get Base directory and file pattern


### PR DESCRIPTION
Fixed US Acquisition import bug.
Bug description: US Acquisition frames are named "basenameXXXXXtrailer" where basename is beginning of the name, XXXXX is the sequence number of the frame and trailer is end of the name. When frame i is missing in the sequence, the US acquisition importer loads the sequence from frame 1 to i-1 ignoring frames i to N.
New behavior: imports all frames from i to N, even if frame i is missing.

The fix uses reg expression to search files named basename?????trailer. The number of "?" set in the reg ex matches the name of the first frame in the sequence.