### PR TITLE
Added to IbisAPI functions needed by SEEGPathPlanning plugin

### DIFF
--- a/IbisLib/filereader.cpp
+++ b/IbisLib/filereader.cpp
@@ -264,6 +264,11 @@ bool FileReader::ConvertMINC1toMINC2( QString &inputileName, QString &outputileN
     }
 }
 
+void FileReader::SetParams( OpenFileParams * params )
+{
+    m_params = params;
+}
+
 void FileReader::SetFileNames( QStringList & filenames )
 {
     m_params = new OpenFileParams;

--- a/IbisLib/filereader.h
+++ b/IbisLib/filereader.h
@@ -25,43 +25,7 @@ class vtkMatrix4x4;
 class ImageObject;
 class PointsObject;
 class IbisAPI;
-
-class OpenFileParams
-{
-
-public:
-
-    struct SingleFileParam
-    {
-        SingleFileParam() : isReference(false), isLabel(false), loadedObject(0), secondaryObject(0), parent(0) {}
-        QString fileName;
-        QString objectName;
-        bool isReference;
-        bool isLabel;  // load image as label image instead of floats.
-        SceneObject * loadedObject;
-        SceneObject * secondaryObject;  // This is a hack to attach the second point object that can be found in PointsObjects
-        SceneObject * parent;
-    };
-    OpenFileParams() : defaultParent(0) {}
-    ~OpenFileParams() {}
-    void AddInputFile( QString filename, QString objectName = QString() )
-    {
-        SingleFileParam p;
-        p.fileName = filename;
-        p.objectName = objectName;
-        filesParams.push_back( p );
-    }
-    void SetAllFileNames( const QStringList & inFiles )
-    {
-        for( int i = 0; i < inFiles.size(); ++i )
-        {
-            AddInputFile( inFiles[i] );
-        }
-    }
-    QList<SingleFileParam> filesParams;
-    QString lastVisitedDir;
-    SceneObject * defaultParent;
-};
+class OpenFileParams;
 
 class FileReader : public QThread
 {
@@ -72,7 +36,7 @@ public:
     FileReader( QObject * parent = 0 );
     ~FileReader();
 
-    void SetParams( OpenFileParams * params ) { m_params = params; }
+    void SetParams( OpenFileParams * params );
     void SetFileNames( QStringList & filenames );  // helper that eventually call SetParams
     void GetReadObjects( QList<SceneObject*> & objects );  // helper
 

--- a/IbisLib/gui/opendatafiledialog.cpp
+++ b/IbisLib/gui/opendatafiledialog.cpp
@@ -13,7 +13,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QFileDialog>
 #include "vtkTransform.h"
 #include "sceneobject.h"
-#include "filereader.h"
+#include "ibisapi.h"
 #include "scenemanager.h"
     
 OpenDataFileDialog::OpenDataFileDialog( QWidget* parent, Qt::WindowFlags fl, SceneManager * man, OpenFileParams *params )

--- a/IbisLib/ibisapi.cpp
+++ b/IbisLib/ibisapi.cpp
@@ -1,5 +1,6 @@
 #include "ibisapi.h"
 #include "application.h"
+#include "filereader.h"
 #include "scenemanager.h"
 #include "mainwindow.h"
 #include "sceneobject.h"
@@ -55,6 +56,11 @@ void IbisAPI::AddObject( SceneObject * object, SceneObject * attachTo )
 void IbisAPI::RemoveObject( SceneObject * object , bool viewChange )
 {
     m_sceneManager->RemoveObject( object, viewChange );
+}
+
+void IbisAPI::RemoveAllChildrenObjects( SceneObject *obj )
+{
+    m_sceneManager->RemoveAllChildrenObjects( obj );
 }
 
 SceneObject *IbisAPI::GetCurrentObject( )
@@ -336,9 +342,19 @@ void IbisAPI::RemoveGlobalEventHandler( GlobalEventHandler * h )
     m_application->RemoveGlobalEventHandler( h );
 }
 
-bool IbisAPI::OpenTransformFile( QString filename, vtkMatrix4x4 * mat )
+bool IbisAPI::OpenTransformFile( const QString & filename, vtkMatrix4x4 * mat )
 {
     return m_application->OpenTransformFile( filename.toUtf8().data(), mat );
+}
+
+bool IbisAPI::OpenTransformFile( const QString & filename, SceneObject * obj )
+{
+    return m_application->OpenTransformFile( filename.toUtf8().data(), obj );
+}
+
+void IbisAPI::OpenFiles( OpenFileParams * params, bool addToScene )
+{
+    m_application->OpenFiles( params, addToScene );
 }
 
 void IbisAPI::SetMainWindowFullscreen( bool f )

--- a/IbisLib/ibisapi.h
+++ b/IbisLib/ibisapi.h
@@ -28,6 +28,43 @@ class vtkMatrix4x4;
 class QProgressDialog;
 class QString;
 
+class OpenFileParams
+{
+
+public:
+
+    struct SingleFileParam
+    {
+        SingleFileParam() : isReference(false), isLabel(false), loadedObject(0), secondaryObject(0), parent(0) {}
+        QString fileName;
+        QString objectName;
+        bool isReference;
+        bool isLabel;  // load image as label image instead of floats.
+        SceneObject * loadedObject;
+        SceneObject * secondaryObject;  // This is a hack to attach the second point object that can be found in PointsObjects
+        SceneObject * parent;
+    };
+    OpenFileParams() : defaultParent(0) {}
+    ~OpenFileParams() {}
+    void AddInputFile( QString filename, QString objectName = QString() )
+    {
+        SingleFileParam p;
+        p.fileName = filename;
+        p.objectName = objectName;
+        filesParams.push_back( p );
+    }
+    void SetAllFileNames( const QStringList & inFiles )
+    {
+        for( int i = 0; i < inFiles.size(); ++i )
+        {
+            AddInputFile( inFiles[i] );
+        }
+    }
+    QList<SingleFileParam> filesParams;
+    QString lastVisitedDir;
+    SceneObject * defaultParent;
+};
+
 class IbisAPI : public QObject
 {
 
@@ -43,6 +80,7 @@ public:
     // from SceneManager:
     void AddObject( SceneObject * object, SceneObject * attachTo = 0 );
     void RemoveObject( SceneObject * object , bool viewChange = true);
+    void RemoveAllChildrenObjects( SceneObject *obj );
     void SetCurrentObject( SceneObject * cur  );
     SceneObject * GetCurrentObject( );
     SceneObject * GetObjectByID( int id );
@@ -108,7 +146,9 @@ public:
     void RemoveGlobalEventHandler( GlobalEventHandler * h );
 
     // Data loading utilities
-    bool OpenTransformFile( QString filename, vtkMatrix4x4 * mat );
+    bool OpenTransformFile( const QString & filename, vtkMatrix4x4 * mat );
+    bool OpenTransformFile( const QString & filename, SceneObject * obj = 0 );
+    void OpenFiles( OpenFileParams * params, bool addToScene = true );
 
     // Control layout of Main Window
     void SetMainWindowFullscreen( bool f );

--- a/IbisLib/mainwindow.cpp
+++ b/IbisLib/mainwindow.cpp
@@ -17,7 +17,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "aboutbicigns.h"
 #include "quadviewwindow.h"
 #include "opendatafiledialog.h"
-#include "filereader.h"
+#include "ibisapi.h"
 #include "worldobject.h"
 #include "ibisconfig.h"
 #include "toolplugininterface.h"

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -38,6 +38,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "pointerobject.h"
 #include "usprobeobject.h"
 #include "filereader.h"
+#include "ibisapi.h"
 #include "application.h"
 #include "hardwaremodule.h"
 #include "objectplugininterface.h"


### PR DESCRIPTION
Moved OpenFileParams from FileReader to IbisAPI in order to discourage direct use of FileReder.