### PR TITLE
Checking validity of ImageObject

### DIFF
--- a/IbisLib/filereader.cpp
+++ b/IbisLib/filereader.cpp
@@ -500,13 +500,14 @@ bool FileReader::OpenItkFile( QList<SceneObject*> & readObjects, QString filenam
 
     IbisItkFloat3ImageType::Pointer itkImage = reader->GetOutput();
     ImageObject * image = ImageObject::New();
+    SetObjectName( image, dataObjectName, filename );
     image->SetItkImage( itkImage );
 
 //    itk::MetaDataDictionary &dictionary = itkImage->GetMetaDataDictionary();
 //    this->PrintMetadata(dictionary);
 
-    SetObjectName( image, dataObjectName, filename );
-    readObjects.push_back( image );
+    if( image->GetImage() != nullptr )
+        readObjects.push_back( image );
 
     ReaderProgress( 1.0 );
 

--- a/IbisLib/filereader.cpp
+++ b/IbisLib/filereader.cpp
@@ -507,9 +507,15 @@ bool FileReader::OpenItkFile( QList<SceneObject*> & readObjects, QString filenam
 //    this->PrintMetadata(dictionary);
 
     if( image->GetImage() != nullptr )
+    {
         readObjects.push_back( image );
-
-    ReaderProgress( 1.0 );
+        ReaderProgress( 1.0 );
+    }
+    else
+    {
+        this->ReportWarning( "Ignoring incomplete data." );
+        return false;
+   }
 
     return true;
 }

--- a/IbisLib/filereader.cpp
+++ b/IbisLib/filereader.cpp
@@ -501,23 +501,17 @@ bool FileReader::OpenItkFile( QList<SceneObject*> & readObjects, QString filenam
     IbisItkFloat3ImageType::Pointer itkImage = reader->GetOutput();
     ImageObject * image = ImageObject::New();
     SetObjectName( image, dataObjectName, filename );
-    image->SetItkImage( itkImage );
-
-//    itk::MetaDataDictionary &dictionary = itkImage->GetMetaDataDictionary();
-//    this->PrintMetadata(dictionary);
-
-    if( image->GetImage() != nullptr )
+    if( image->SetItkImage( itkImage ) )
     {
         readObjects.push_back( image );
         ReaderProgress( 1.0 );
-    }
-    else
-    {
-        this->ReportWarning( "Ignoring incomplete data." );
-        return false;
-   }
+        //    itk::MetaDataDictionary &dictionary = itkImage->GetMetaDataDictionary();
+        //    this->PrintMetadata(dictionary);
 
-    return true;
+        return true;
+    }
+    this->ReportWarning( "Ignoring incomplete data." );
+    return false;
 }
 
 bool FileReader::OpenItkLabelFile( QList<SceneObject*> & readObjects, QString filename, const QString & dataObjectName )
@@ -540,14 +534,17 @@ bool FileReader::OpenItkLabelFile( QList<SceneObject*> & readObjects, QString fi
 
     IbisItkUnsignedChar3ImageType::Pointer itkImage = reader->GetOutput();
     ImageObject * image = ImageObject::New();
-    image->SetItkLabelImage( itkImage );
+    if( image->SetItkLabelImage( itkImage ) )
+    {
+        SetObjectName( image, dataObjectName, filename );
+        readObjects.push_back( image );
 
-    SetObjectName( image, dataObjectName, filename );
-    readObjects.push_back( image );
+        ReaderProgress( 1.0 );
 
-    ReaderProgress( 1.0 );
-
-    return true;
+        return true;
+    }
+    this->ReportWarning( "Ignoring incomplete data." );
+    return false;
 }
 
 bool FileReader::OpenObjFile( QList<SceneObject*> & readObjects, QString filename, const QString & dataObjectName )

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -229,9 +229,6 @@ void ImageObject::SetItkImage( IbisItkFloat3ImageType::Pointer image )
     ImageType::PixelType maxPix = imageCalculatorFilter->GetMaximum();
     if( isnan(minPix) || isnan(maxPix) || isinf(minPix) || isinf(maxPix) )
     {
-        QString msg( "Incomplete data, ignoring object:  " );
-        msg.append( this->GetName() );
-        QMessageBox::warning( nullptr, "Error",msg , 1, 0 );
         return;
     }
 

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -255,7 +255,7 @@ bool ImageObject::SetItkImage( IbisItkFloat3ImageType::Pointer image )
     if( !SanityCheck( image ) )
         return false;
     this->ItkImage = image;
-   if( this->ItkImage )
+    if( this->ItkImage )
     {
         vtkTransform * rotTrans = vtkTransform::New();
         this->SetImage( this->ItktovtkConverter->ConvertItkImageToVtkImage( this->ItkImage, rotTrans ) );

--- a/IbisLib/imageobject.cpp
+++ b/IbisLib/imageobject.cpp
@@ -129,6 +129,10 @@ void ImageObject::Serialize( Serializer * ser )
     if( !ser->IsReader() )
     {
         labelImage = this->IsLabelImage();
+        if( !isnan(this->lutRange[0]) )
+            this->lutRange[0] = 0.0;
+        if( !isnan(this->lutRange[1]) )
+            this->lutRange[1] = 0.0;
     }
     ::Serialize( ser, "LabelImage", labelImage );
     ::Serialize( ser, "ViewOutline", this->viewOutline );
@@ -174,6 +178,10 @@ void ImageObject::Serialize( Serializer * ser )
         m_volumeProperty->SetSpecular( specular );
         m_volumeProperty->SetSpecularPower( specularPower );
         m_volumeProperty->SetDisableGradientOpacity( enableGradientOpacity ? 0 : 1 );
+        if( isnan(this->lutRange[0]) )
+            this->lutRange[0] = 0.0;
+        if( isnan(this->lutRange[1]) )
+            this->lutRange[1] = 0.0;
     }
     ::Serialize( ser, "ScalarOpacity", m_volumeProperty->GetScalarOpacity() );
     ::Serialize( ser, "GradientOpacity", m_volumeProperty->GetGradientOpacity() );

--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -44,7 +44,7 @@ public:
         
     static ImageObject * New() { return new ImageObject; }
     vtkTypeMacro(ImageObject,SceneObject);
-    
+
     ImageObject();
     virtual ~ImageObject();
     
@@ -56,8 +56,8 @@ public:
     bool IsLabelImage();
     
     vtkImageData* GetImage( );
-    void SetItkImage( IbisItkFloat3ImageType::Pointer image );  // for all others
-    void SetItkLabelImage( IbisItkUnsignedChar3ImageType::Pointer image );  // for labels
+    bool SetItkImage( IbisItkFloat3ImageType::Pointer image );  // for all others
+    bool SetItkLabelImage( IbisItkUnsignedChar3ImageType::Pointer image );  // for labels
     IbisItkFloat3ImageType::Pointer GetItkImage() { return this->ItkImage; }
     IbisItkUnsignedChar3ImageType::Pointer GetItkLabelImage() { return this->ItkLabelImage; }
     void SetImage( vtkImageData * image );
@@ -172,6 +172,9 @@ protected:
     
     typedef std::map<View*,PerViewElements*> ImageObjectViewAssociation;
     ImageObjectViewAssociation imageObjectInstances;
+
+    bool SanityCheck( IbisItkFloat3ImageType::Pointer image );
+    bool SanityCheck( IbisItkUnsignedChar3ImageType::Pointer image );
 };
 
 ObjectSerializationHeaderMacro( ImageObject );

--- a/IbisPlugins/GPUVolumeReconstructionAPITest/gpuvolumereconstructionapitestplugininterface.cpp
+++ b/IbisPlugins/GPUVolumeReconstructionAPITest/gpuvolumereconstructionapitestplugininterface.cpp
@@ -65,12 +65,16 @@ QWidget * GPUVolumeReconstructionAPITestPluginInterface::CreateFloatingWidget()
             reconstructor->wait();
 
             vtkSmartPointer<ImageObject> reconstructedImage = vtkSmartPointer<ImageObject>::New();
-            reconstructedImage->SetItkImage( reconstructor->GetReconstructedImage() );
-            QString volName("ReconstructedVolume");
-            volName.append( QString::number( i ) );
-            reconstructedImage->SetName(volName);
-            ibisAPI->AddObject(reconstructedImage, acq->GetParent()->GetParent() );
-            ibisAPI->SetCurrentObject( reconstructedImage );
+            if( reconstructedImage->SetItkImage( reconstructor->GetReconstructedImage() ) )
+            {
+                QString volName("ReconstructedVolume");
+                volName.append( QString::number( i ) );
+                reconstructedImage->SetName(volName);
+                ibisAPI->AddObject(reconstructedImage, acq->GetParent()->GetParent() );
+                ibisAPI->SetCurrentObject( reconstructedImage );
+            }
+            else
+                QMessageBox::warning( 0, "Error", "Reconstruction failed." );
         }
         reconstructor->Delete();
         return 0;

--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
@@ -73,16 +73,24 @@ void GPU_VolumeReconstructionWidget::slot_finished()
     reconstructedImage->SetName("Reconstructed Volume");
     reconstructedImage->SetItkImage( m_VolumeReconstructor->GetReconstructedImage() );
 
-    ibisAPI->AddObject(reconstructedImage, selectedUSAcquisitionObject->GetParent()->GetParent() );
-    ibisAPI->SetCurrentObject( reconstructedImage );
+    if( reconstructedImage->GetImage() != nullptr )
+    {
+        ibisAPI->AddObject(reconstructedImage, selectedUSAcquisitionObject->GetParent()->GetParent() );
+        ibisAPI->SetCurrentObject( reconstructedImage );
 
 #ifdef DEBUG
     std::cerr << "Done..." << std::endl;
     std::cout << "Volume Reconstruction took " << qreal(reconstructionTime)/1000.0 << "secs"<< std::endl;
 #endif
 
-    QString feedbackString = QString("Volume Reconstruction finished in %1 secs").arg(qreal(reconstructionTime)/1000.0);
-    ui->userFeedbackLabel->setText(feedbackString);
+        QString feedbackString = QString("Volume Reconstruction finished in %1 secs").arg(qreal(reconstructionTime)/1000.0);
+        ui->userFeedbackLabel->setText(feedbackString);
+    }
+    else
+    {
+        QString feedbackString = QString("Reconstruction failed.");
+        ui->userFeedbackLabel->setText(feedbackString);
+    }
 
     ui->progressBar->hide();
 }

--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
@@ -71,9 +71,7 @@ void GPU_VolumeReconstructionWidget::slot_finished()
     //Add Reconstructed Volume to Scene
     vtkSmartPointer<ImageObject> reconstructedImage = vtkSmartPointer<ImageObject>::New();
     reconstructedImage->SetName("Reconstructed Volume");
-    reconstructedImage->SetItkImage( m_VolumeReconstructor->GetReconstructedImage() );
-
-    if( reconstructedImage->GetImage() != nullptr )
+    if( reconstructedImage->SetItkImage( m_VolumeReconstructor->GetReconstructedImage() ) )
     {
         ibisAPI->AddObject(reconstructedImage, selectedUSAcquisitionObject->GetParent()->GetParent() );
         ibisAPI->SetCurrentObject( reconstructedImage );


### PR DESCRIPTION
We have some empty reconstructed volumes with invalid scalar range. Checking the range allows us to discard the data and avoid crash.
