### PR TITLE
Added tool status in IGSIO plugin

### DIFF
--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -38,6 +38,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "igtlioImageConverter.h"
 #include "igtlioTransformConverter.h"
 #include "igtlioVideoConverter.h"
+#include "igtlioStatusDevice.h"
 
 IbisHardwareIGSIO::IbisHardwareIGSIO()
 {
@@ -78,6 +79,7 @@ void IbisHardwareIGSIO::Init()
     m_logicController->setLogic( m_logic );
     m_logicCallbacks->Connect( m_logic, igtlioLogic::NewDeviceEvent, this, SLOT(OnDeviceNew(vtkObject*, unsigned long, void*, void*)) );
     m_logicCallbacks->Connect( m_logic, igtlioLogic::RemovedDeviceEvent, this, SLOT(OnDeviceRemoved(vtkObject*, unsigned long, void*, void*)) );
+
 
     // Initialize with last config file
     if( m_autoStartLastConfig )
@@ -139,10 +141,13 @@ void IbisHardwareIGSIO::ClearConfig()
 
 TrackerToolState StatusStringToState( const std::string & status )
 {
-    if( status == "true" )
+    QString qstatus(status.c_str());
+    if( qstatus.toUpper().toStdString() == "OK" )
         return Ok;
-    if( status == "false" )
+    if( qstatus.toUpper().toStdString() == "OUTOFVOLUME" )
         return OutOfView;
+    if( qstatus.toUpper().toStdString() == "MISSING" )
+        return Missing;
     return Undefined;
 }
 
@@ -154,20 +159,34 @@ void IbisHardwareIGSIO::Update()
     // Push images, transforms and states to the TrackedSceneObjects
     foreach( Tool * tool, m_tools )
     {
+
         if( tool->transformDevice )
         {
             if( tool->transformDevice->GetDeviceType() == igtlioImageConverter::GetIGTLTypeName() )
             {
                 igtlioImageDevice * imageDevice = igtlioImageDevice::SafeDownCast( tool->transformDevice );
                 tool->sceneObject->SetInputMatrix( imageDevice->GetContent().transform );
-                tool->sceneObject->SetState( Ok );
+                // Copy transform status from metadata to node attributes
+                for (igtl::MessageBase::MetaDataMap::const_iterator iter = transformDevice->GetMetaData().begin(); iter != transformDevice->GetMetaData().end(); ++iter)
+                {
+                  if (iter->first.find("Status") != std::string::npos)
+                  {
+                    tool->sceneObject->SetState( StatusStringToState( iter->second.second.c_str() ) );
+                  }
+                }
             }
             else if( tool->transformDevice->GetDeviceType() == igtlioTransformConverter::GetIGTLTypeName() )
             {
                 igtlioTransformDevice * transformDevice = igtlioTransformDevice::SafeDownCast( tool->transformDevice );
                 tool->sceneObject->SetInputMatrix( transformDevice->GetContent().transform );
-                //tool->sceneObject->SetState( StatusStringToState( transformDevice->GetContent().transformStatus ) );
-                tool->sceneObject->SetState( Ok );
+                // Copy transform status from metadata to node attributes
+                for (igtl::MessageBase::MetaDataMap::const_iterator iter = transformDevice->GetMetaData().begin(); iter != transformDevice->GetMetaData().end(); ++iter)
+                {
+                  if (iter->first.find("Status") != std::string::npos)
+                  {
+                    tool->sceneObject->SetState( StatusStringToState( iter->second.second.c_str() ) );
+                  }
+                }
             }
         }
         if( tool->imageDevice )
@@ -408,7 +427,28 @@ void IbisHardwareIGSIO::Connect( std::string ip, int port )
     igtlioConnectorPointer c = m_logic->CreateConnector();
     c->SetTypeClient( ip, port );
     c->Start();
+    m_logicCallbacks->Connect( c , igtlioConnector::ConnectedEvent, this, SLOT(OnConnectionEstablished(vtkObject*, unsigned long, void*, void*)) );
 }
+
+void IbisHardwareIGSIO::OnConnectionEstablished(vtkObject* caller, unsigned long, void*, void *)
+{
+    // send a dummy message with metadata to force v2 message exchange
+    igtlioConnectorPointer connector = reinterpret_cast<igtlioConnector *>(caller);
+    igtlioDeviceKeyType key;
+    key.name = "";
+    key.type = "STATUS";
+    vtkSmartPointer<igtlioStatusDevice> statusDevice = igtlioStatusDevice::SafeDownCast(connector->GetDevice(key));
+    if (!statusDevice)
+    {
+      statusDevice = vtkSmartPointer<igtlioStatusDevice>::New();
+      connector->AddDevice(statusDevice);
+    }
+
+    statusDevice->SetMetaDataElement("dummy", "dummy"); // existence of metadata makes the IO connector send a header v2 message
+    connector->SendMessage(igtlioDeviceKeyType::CreateDeviceKey(statusDevice));
+    connector->RemoveDevice(statusDevice);
+}
+
 
 void IbisHardwareIGSIO::DisconnectAllServers()
 {
@@ -515,3 +555,4 @@ bool IbisHardwareIGSIO::IsDeviceVideo( igtlioDevicePointer device )
 {
     return device->GetDeviceType() == igtlioVideoConverter::GetIGTLTypeName();
 }
+

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -167,7 +167,7 @@ void IbisHardwareIGSIO::Update()
                 igtlioImageDevice * imageDevice = igtlioImageDevice::SafeDownCast( tool->transformDevice );
                 tool->sceneObject->SetInputMatrix( imageDevice->GetContent().transform );
                 // Copy transform status from metadata to node attributes
-                for (igtl::MessageBase::MetaDataMap::const_iterator iter = transformDevice->GetMetaData().begin(); iter != transformDevice->GetMetaData().end(); ++iter)
+                for (igtl::MessageBase::MetaDataMap::const_iterator iter = imageDevice->GetMetaData().begin(); iter != imageDevice->GetMetaData().end(); ++iter)
                 {
                   if (iter->first.find("Status") != std::string::npos)
                   {

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.h
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.h
@@ -115,7 +115,6 @@ protected:
         vtkSmartPointer<PolyDataObject> toolModel;
         igtlioDevicePointer transformDevice;
         igtlioDevicePointer imageDevice;
-//        igtlio
     };
     typedef QList< Tool* > toolList;
     toolList m_tools;

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.h
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.h
@@ -16,6 +16,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "configio.h"
 
 class igtlioLogic;
+class igtlioConnector;
 
 class QMenu;
 class qIGTLIOLogicController;
@@ -86,6 +87,7 @@ private slots:
     void OnConfigFileWidgetClosed();
     void OnDeviceNew( vtkObject*, unsigned long, void*, void* );
     void OnDeviceRemoved( vtkObject*, unsigned long, void*, void* );
+    void OnConnectionEstablished( vtkObject*, unsigned long, void*, void* );
 
 protected:
 
@@ -106,12 +108,14 @@ protected:
     bool IsDeviceTransform( igtlioDevicePointer device );
     bool IsDeviceVideo( igtlioDevicePointer device );
 
+
     struct Tool
     {
         vtkSmartPointer<TrackedSceneObject> sceneObject;
         vtkSmartPointer<PolyDataObject> toolModel;
         igtlioDevicePointer transformDevice;
         igtlioDevicePointer imageDevice;
+//        igtlio
     };
     typedef QList< Tool* > toolList;
     toolList m_tools;


### PR DESCRIPTION
To enable Plus to send metadata (that includes tracked tool status), the connector needs to initiate a version 2 message header communication by sending a dummy message with metadata.

- The dummy message is send after the connection to the plus server (this needs to be done via a igtlioConnector::ConnectedEvent callback to avoid any connection latency)
- Modified the StatusStringToState function to read tool status (may need more status management)
