### PR TITLE
GPU Plugins compilation on Windows

### DIFF
--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
@@ -44,6 +44,8 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
   /* Initialize GPU Context */
   this->InitializeGPUContext();
 
+  m_OrientationMatchingKernel = 0;
+
   m_Percentile = 0.9;
   m_N = 2;
 
@@ -112,11 +114,7 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
   m_CommandQueue = (cl_command_queue *)malloc(m_NumberOfDevices * sizeof(cl_command_queue) );
   for(unsigned int i=0; i<m_NumberOfDevices; i++)
     {
-#ifdef __APPLE__
     m_CommandQueue[i] = clCreateCommandQueue(m_Context, m_Devices[i], 0, &errid);
-#else
-    m_CommandQueue[i] = clCreateCommandQueueWithProperties(m_Context, m_Devices[i], 0, &errid);
-#endif
     OpenCLCheckError( errid, __FILE__, __LINE__, ITK_LOCATION );
     }  
 }

--- a/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
+++ b/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
@@ -43,6 +43,7 @@ GPUVolumeReconstruction< TImage >
   /* Initialize GPU Context */
   this->InitializeGPUContext();
 
+  m_VolumeReconstructionPopulatingKernel = 0;
   m_NumberOfSlices = 0;  
 
   m_USSearchRadius = 0;
@@ -97,11 +98,7 @@ GPUVolumeReconstruction< TImage >
   m_CommandQueue = (cl_command_queue *)malloc(m_NumberOfDevices * sizeof(cl_command_queue) );
   for(unsigned int i=0; i<m_NumberOfDevices; i++)
     {
-#ifdef __APPLE__
     m_CommandQueue[i] = clCreateCommandQueue(m_Context, m_Devices[i], 0, &errid);
-#else
-    m_CommandQueue[i] = clCreateCommandQueueWithProperties(m_Context, m_Devices[i], 0, &errid);
-#endif
     OpenCLCheckError( errid, __FILE__, __LINE__, ITK_LOCATION );
     }
 

--- a/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
+++ b/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
@@ -39,11 +39,11 @@ GPUVolumeReconstruction< TImage >
   }
 
   m_Debug = false;
+  m_VolumeReconstructionPopulatingKernel = 0;
 
   /* Initialize GPU Context */
   this->InitializeGPUContext();
 
-  m_VolumeReconstructionPopulatingKernel = 0;
   m_NumberOfSlices = 0;  
 
   m_USSearchRadius = 0;


### PR DESCRIPTION
- clCreateCommandQueueWithProperties only supported on OpenCL 2.0 replaced by clCreateCommandQueue
- m_OrientationMatchingKernel was not initialized and caused occasional crashes when registration process is called outside of the plugin interface
- same for m_VolumeReconstructionPopulatingKernel
- Registration and Reconstruction plugins are working on Windows 10 and Ubuntu 18.04, and need to be tested on Mac