### PR TITLE
Removed pointer calibration from Hardware module entirely.

### DIFF
--- a/IbisHardware/ibishardwaremodule.cpp
+++ b/IbisHardware/ibishardwaremodule.cpp
@@ -112,34 +112,6 @@ void IbisHardwareModule::RemoveTrackedVideoClient( TrackedSceneObject * obj )
     return m_tracker->GetVideoSource( obj )->RemoveClient();
 }
 
-void IbisHardwareModule::StartTipCalibration( PointerObject * p )
-{
-    vtkTrackerTool * tool = m_tracker->GetTool( p );
-    Q_ASSERT( tool );
-    tool->StartTipCalibration();
-}
-
-double IbisHardwareModule::DoTipCalibration( PointerObject * p, vtkMatrix4x4 * calibMat )
-{
-    vtkTrackerTool * tool = m_tracker->GetTool( p );
-    Q_ASSERT( tool );
-    return tool->DoToolTipCalibration( calibMat );
-}
-
-bool IbisHardwareModule::IsCalibratingTip( PointerObject * p )
-{
-    vtkTrackerTool * tool = m_tracker->GetTool( p );
-    Q_ASSERT( tool );
-    return tool->GetCalibrating() > 0 ? true : false;
-}
-
-void IbisHardwareModule::StopTipCalibration( PointerObject * p )
-{
-    vtkTrackerTool * tool = m_tracker->GetTool( p );
-    Q_ASSERT( tool );
-    tool->StopTipCalibration();
-}
-
 void IbisHardwareModule::OpenVideoSettingsDialog()
 {
     QDialog * dialog = new QDialog();

--- a/IbisHardware/ibishardwaremodule.h
+++ b/IbisHardware/ibishardwaremodule.h
@@ -54,11 +54,6 @@ public:
     virtual void AddTrackedVideoClient( TrackedSceneObject * obj ) override;
     virtual void RemoveTrackedVideoClient( TrackedSceneObject * obj) override;
 
-    virtual void StartTipCalibration( PointerObject * p ) override;
-    virtual double DoTipCalibration( PointerObject * p, vtkMatrix4x4 * calibMat ) override;
-    virtual bool IsCalibratingTip( PointerObject * p ) override;
-    virtual void StopTipCalibration( PointerObject * p ) override;
-
     // Local methods
     TrackedVideoSource * GetVideoSource( int index ) { return m_trackedVideoSource; } // simtodo : allow more than one source
 

--- a/IbisHardware/vtkTracker/vtkTrackerTool.h
+++ b/IbisHardware/vtkTracker/vtkTrackerTool.h
@@ -96,19 +96,6 @@ public:
   vtkMatrix4x4 *GetCalibrationMatrix();
 
   // Description:
-  // Perform a calibration of the position of the tool tip.  To accomplish
-  // this, first call StartTipCalibration() to start accumulating points
-  // then call DoToolTipCalibration to compute calib matrix with points
-  // already accumulated. The value returned by DoToolTipCalibration()
-  // is the uncertainty (one standard deviation) in the position of the
-  // origin for any particular measurement.
-  void StartTipCalibration();
-  int InsertNextCalibrationPoint();
-  double DoToolTipCalibration( vtkMatrix4x4 * calibMat );
-  void StopTipCalibration();
-  vtkGetMacro(Calibrating,int);
-
-  // Description:
   // Get additional information about the transform for the latest update:
   // <p>Missing:     there is no tool plugged into this port.
   // <p>OutOfView:   tracker is temporarily unable to supply a transform.
@@ -191,11 +178,6 @@ protected:
   vtkMatrix4x4 *CalibrationMatrix;
   bool UpdateLocked;
 
-  int Calibrating;
-  vtkCriticalSection * CalibrationMutex;
-  vtkAmoebaMinimizer *Minimizer;
-  vtkDoubleArray *CalibrationArray;
-
   int Flags;
 
   double TimeStamp;
@@ -211,10 +193,6 @@ protected:
   char *ToolManufacturer;
 
   vtkTrackerBuffer *Buffer;
-
-//BTX
-  friend void vtkTrackerToolCalibrationFunction(void *userData);
-//ETX
 
 private:
   vtkTrackerTool(const vtkTrackerTool&);

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -260,24 +260,6 @@ void IbisHardwareIGSIO::RemoveTrackedVideoClient( TrackedSceneObject * obj )
 {
 }
 
-void IbisHardwareIGSIO::StartTipCalibration( PointerObject * p )
-{
-}
-
-double IbisHardwareIGSIO::DoTipCalibration( PointerObject * p, vtkMatrix4x4 * calibMat )
-{
-    return 0.0;
-}
-
-bool IbisHardwareIGSIO::IsCalibratingTip( PointerObject * p )
-{
-    return false;
-}
-
-void IbisHardwareIGSIO::StopTipCalibration( PointerObject * p )
-{
-}
-
 void IbisHardwareIGSIO::OpenSettingsWidget()
 {
     if( !m_clientWidget )

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.h
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.h
@@ -74,11 +74,6 @@ public:
     virtual void AddTrackedVideoClient( TrackedSceneObject * obj ) override;
     virtual void RemoveTrackedVideoClient( TrackedSceneObject * obj) override;
 
-    virtual void StartTipCalibration( PointerObject * p ) override;
-    virtual double DoTipCalibration( PointerObject * p, vtkMatrix4x4 * calibMat ) override;
-    virtual bool IsCalibratingTip( PointerObject * p ) override;
-    virtual void StopTipCalibration( PointerObject * p ) override;
-
 private slots:
 
     void OpenSettingsWidget();

--- a/IbisLib/hardwaremodule.h
+++ b/IbisLib/hardwaremodule.h
@@ -51,11 +51,6 @@ public:
     virtual void AddTrackedVideoClient( TrackedSceneObject * obj ) = 0;
     virtual void RemoveTrackedVideoClient( TrackedSceneObject * obj) = 0;
 
-    virtual void StartTipCalibration( PointerObject * p ) = 0;
-    virtual double DoTipCalibration( PointerObject * p, vtkMatrix4x4 * calibMat ) = 0;
-    virtual bool IsCalibratingTip( PointerObject * p ) = 0;
-    virtual void StopTipCalibration( PointerObject * p ) = 0;
-
 };
 
 #endif

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -183,15 +183,7 @@ void SceneManager::Clear()
 {
     disconnect( this->MainCutPlanes, SIGNAL(PlaneMoved(int)), this, SLOT(OnCutPlanesPositionChanged()) );
     disconnect( this, SIGNAL(ReferenceObjectChanged()), this->MainCutPlanes, SLOT(AdjustAllImages()) );
-    std::cout << "BEFORE" << std::endl;
-    for(int i = 0 ; i < AllObjects.size() ; i++ ){
-        std::cout << AllObjects.at(i)->GetName().toStdString() << std::endl;
-    }
     this->RemoveAllSceneObjects();
-    std::cout << "AFTER" << std::endl;
-    for(int i = 0 ; i < AllObjects.size() ; i++ ){
-        std::cout << AllObjects.at(i)->GetName().toStdString() << std::endl;
-    }
     Q_ASSERT_X( AllObjects.size() == 0, "SceneManager::~SceneManager()", "Objects are left in the global list.");
     m_sceneRoot->Delete();
     m_sceneRoot = nullptr;

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -183,7 +183,15 @@ void SceneManager::Clear()
 {
     disconnect( this->MainCutPlanes, SIGNAL(PlaneMoved(int)), this, SLOT(OnCutPlanesPositionChanged()) );
     disconnect( this, SIGNAL(ReferenceObjectChanged()), this->MainCutPlanes, SLOT(AdjustAllImages()) );
+    std::cout << "BEFORE" << std::endl;
+    for(int i = 0 ; i < AllObjects.size() ; i++ ){
+        std::cout << AllObjects.at(i)->GetName().toStdString() << std::endl;
+    }
     this->RemoveAllSceneObjects();
+    std::cout << "AFTER" << std::endl;
+    for(int i = 0 ; i < AllObjects.size() ; i++ ){
+        std::cout << AllObjects.at(i)->GetName().toStdString() << std::endl;
+    }
     Q_ASSERT_X( AllObjects.size() == 0, "SceneManager::~SceneManager()", "Objects are left in the global list.");
     m_sceneRoot->Delete();
     m_sceneRoot = nullptr;


### PR DESCRIPTION
The duplication of vtkTrackerToolCalibrationFunction caused a compilation error making it impossible to compile the old Hardware module with the latest PointerObject class.