### PR TITLE
Open cl declaration

### DIFF
--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
@@ -44,6 +44,7 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
   /* Initialize GPU Context */
   this->InitializeGPUContext();
 
+  m_OrientationMatchingKernel = 0;
   m_Percentile = 0.9;
   m_N = 2;
 

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
@@ -114,6 +114,8 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
     {
 #ifdef __APPLE__
     m_CommandQueue[i] = clCreateCommandQueue(m_Context, m_Devices[i], 0, &errid);
+#elif defined(WIN32) || defined(_WIN32)
+	  m_CommandQueue[i] = clCreateCommandQueue(m_Context, m_Devices[i], 0, &errid);
 #else
     m_CommandQueue[i] = clCreateCommandQueueWithProperties(m_Context, m_Devices[i], 0, &errid);
 #endif

--- a/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
+++ b/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
@@ -39,6 +39,7 @@ GPUVolumeReconstruction< TImage >
   }
 
   m_Debug = false;
+  m_VolumeReconstructionPopulatingKernel = 0;
 
   /* Initialize GPU Context */
   this->InitializeGPUContext();

--- a/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
+++ b/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
@@ -99,6 +99,8 @@ GPUVolumeReconstruction< TImage >
     {
 #ifdef __APPLE__
     m_CommandQueue[i] = clCreateCommandQueue(m_Context, m_Devices[i], 0, &errid);
+#elif defined(WIN32) || defined(_WIN32)
+	  m_CommandQueue[i] = clCreateCommandQueue(m_Context, m_Devices[i], 0, &errid);
 #else
     m_CommandQueue[i] = clCreateCommandQueueWithProperties(m_Context, m_Devices[i], 0, &errid);
 #endif


### PR DESCRIPTION
- clCreateCommandQueueWithProperties only supported on OpenCL 2.0 replaced by clCreateCommandQueue
- m_OrientationMatchingKernel was not initialized and caused occasional crashes when the registration process is called outside of the plugin interface
- same for m_VolumeReconstructionPopulatingKernel