### PR TITLE
Us manual calibration plugin

### DIFF
--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectplugininterface.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectplugininterface.cpp
@@ -22,15 +22,18 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 LandmarkRegistrationObjectPluginInterface::LandmarkRegistrationObjectPluginInterface()
 {
+	m_landmarkRegistrationObject = vtkSmartPointer<LandmarkRegistrationObject>::New();
+	m_landmarkRegistrationObject->SetName("Landmark Registration");
+	m_landmarkRegistrationObject->SetCanEditTransformManually(false);
 }
 
 LandmarkRegistrationObjectPluginInterface::~LandmarkRegistrationObjectPluginInterface()
 {
+	m_landmarkRegistrationObject = 0;
 }
 
 SceneObject *LandmarkRegistrationObjectPluginInterface::CreateObject()
 {
-    m_landmarkRegistrationObject = 0;
     IbisAPI *ibisAPI = GetIbisAPI();
     Q_ASSERT(ibisAPI);
     vtkSmartPointer<PointsObject>sourcePoints = vtkSmartPointer<PointsObject>::New();
@@ -47,9 +50,6 @@ SceneObject *LandmarkRegistrationObjectPluginInterface::CreateObject()
     targetPoints->SetSelectedColor(color1);
     double color2[3] = {0.3, 0.3, 1.0};
     targetPoints->SetDisabledColor(color2);
-    m_landmarkRegistrationObject = vtkSmartPointer<LandmarkRegistrationObject>::New();
-    m_landmarkRegistrationObject->SetName( "Landmark Registration" );
-    m_landmarkRegistrationObject->SetCanEditTransformManually( false );
     ibisAPI->AddObject( m_landmarkRegistrationObject );
     ibisAPI->AddObject( sourcePoints, m_landmarkRegistrationObject );
     ibisAPI->AddObject( targetPoints, ibisAPI->GetSceneRoot() );

--- a/IbisPlugins/USManualCalibration/usmanualcalibrationplugininterface.cpp
+++ b/IbisPlugins/USManualCalibration/usmanualcalibrationplugininterface.cpp
@@ -171,7 +171,7 @@ void USManualCalibrationPluginInterface::BuildCalibrationPhantomRepresentation()
 void USManualCalibrationPluginInterface::StartPhantomRegistration()
 {
     const char * pointNames[4] = { "One", "Two", "Three", "Four" };
-    double pointCoords[4][3] = { { 2.5, 2.5, 48.0 }, { 2.5, 47.5, 48 }, { 47.5, 2.5, 48 }, {  47.5, 47.5, 48 } };
+    double pointCoords[4][3] = { { 0, -17.5, 53 }, { 50, -17.5, 53 }, { 42, 112.5, 53 }, {  10, 80, 53 } };
 
     if( m_calibrationPhantomObjectId == IbisAPI::InvalidId )
         BuildCalibrationPhantomRepresentation();

--- a/IbisPlugins/USManualCalibration/usmanualcalibrationwidget.cpp
+++ b/IbisPlugins/USManualCalibration/usmanualcalibrationwidget.cpp
@@ -313,7 +313,7 @@ void USManualCalibrationWidget::OnManipulatorsModified()
         // Compute each manipulator's center point position in phantom coordinate
         vtkMatrix4x4 * phantomToWorldMat = vtkMatrix4x4::New();
         m_pluginInterface->GetCalibrationPhantomObject()->GetWorldTransform()->GetMatrix( phantomToWorldMat );
-        double manipWorldCoords[4][3];
+        double manipWorldCoords[4][4];
         for( int i = 0; i < 4; ++i )
         {
             // Get phantom space coord


### PR DESCRIPTION
Plugin Update:
- Created a 3D CAD model of the calibration phantom (we should upload the .stl file to http://ibisneuronav.org)
- Updated the point coordinates to match the new calibration phantom (for landmark registration)
- Fixed a couple of bug on Windows:
-- manipWorldCoords is a 4x4 not 4x3
-- initialize m_landmarkRegistrationObject in constructor instead of in CreateObject() function, due to vtkSmartPointer deleting the pointer after CreateObject() call causing Ibis to crash when reloading the plugin on Windows