### PR TITLE
Allow US volume reconstruction without mask

### DIFF
--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
@@ -146,13 +146,6 @@ void GPU_VolumeReconstructionWidget::on_startButton_clicked()
 	{
 		m_VolumeReconstructor->SetFixedSliceMask(selectedUSAcquisitionObject->GetMask());
 	}
-	else
-	{
-		vtkSmartPointer<vtkImageData> img = vtkSmartPointer<vtkImageData>::New();
-		vtkMatrix4x4 *mat = vtkMatrix4x4::New();
-		selectedUSAcquisitionObject->GetFrameData(0, img, mat);
-		m_VolumeReconstructor->SetFixedSliceMask(img);
-	}
     m_VolumeReconstructor->SetUSSearchRadius( usSearchRadius );
     m_VolumeReconstructor->SetVolumeSpacing( usVolumeSpacing );
     m_VolumeReconstructor->SetKernelStdDev( usVolumeSpacing/2.0 );

--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
@@ -142,7 +142,17 @@ void GPU_VolumeReconstructionWidget::on_startButton_clicked()
     std::cerr << "Constructing m_Reconstructor..." << std::endl;
 #endif
     m_VolumeReconstructor->SetNumberOfSlices( nbrOfSlices );
-    m_VolumeReconstructor->SetFixedSliceMask( selectedUSAcquisitionObject->GetMask() );
+	if (selectedUSAcquisitionObject->IsUsingMask())
+	{
+		m_VolumeReconstructor->SetFixedSliceMask(selectedUSAcquisitionObject->GetMask());
+	}
+	else
+	{
+		vtkSmartPointer<vtkImageData> img = vtkSmartPointer<vtkImageData>::New();
+		vtkMatrix4x4 *mat = vtkMatrix4x4::New();
+		selectedUSAcquisitionObject->GetFrameData(0, img, mat);
+		m_VolumeReconstructor->SetFixedSliceMask(img);
+	}
     m_VolumeReconstructor->SetUSSearchRadius( usSearchRadius );
     m_VolumeReconstructor->SetVolumeSpacing( usVolumeSpacing );
     m_VolumeReconstructor->SetKernelStdDev( usVolumeSpacing/2.0 );

--- a/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
+++ b/IbisPlugins/GPU_VolumeReconstruction/itkVolumeReconstructionOpenCL/itkGPUVolumeReconstruction.hxx
@@ -21,6 +21,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "itkOpenCLUtil.h"
 
 #include "GPUVolumeReconstructionKernel.h"
+#include "itkImageDuplicator.h"
 
 
 namespace itk
@@ -428,7 +429,12 @@ GPUVolumeReconstruction< TImage >
 
   if( m_FixedSliceMask == nullptr )
   {
-    itkExceptionMacro(<< "Slice Mask has not been set." );
+	  using DuplicatorType = itk::ImageDuplicator< ImageType >;
+	  typename DuplicatorType::Pointer duplicator = DuplicatorType::New();
+	  duplicator->SetInputImage(m_FixedSlices[0]);
+	  duplicator->Update();
+	  m_FixedSliceMask = duplicator->GetOutput();
+	  m_FixedSliceMask->FillBuffer(1);
   }
   m_FixedSliceMask->Update();
 


### PR DESCRIPTION
Volume reconstruction plugin performs reconstruction of masked acquisitions only.
Modified plugin widget to check if the acquisition is masked or not:
- if masked: the plugin passes the mask to the reconstructor (unchanged)
- if not masked: the plugin creates a mask containing the entire image from the first frame (new feature)