### PR TITLE
Remove maximum kernel size to avoid worning message

### DIFF
--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
@@ -281,7 +281,6 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
     s = s*s;
     opers[dim].SetVariance(m_GradientScale / s);
     
-    opers[dim].SetMaximumKernelWidth(5);
     opers[dim].CreateDirectional();  
 
     unsigned int numberOfElements = 1;  
@@ -715,7 +714,6 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
     s = s*s;
     opers[dim].SetVariance(m_GradientScale / s);
     
-    opers[dim].SetMaximumKernelWidth(5);
     opers[dim].CreateDirectional();  
 
     unsigned int numberOfElements = 1;  


### PR DESCRIPTION
itkGaussianDerivativeOperator automatically sets the width of the kernel according to the default maximum error of Gaussian curve approximation. Setting a maximum kernel size may lead to truncate the kernel and raises a warning message.