### PR TITLE
Add masking option in reconstruction plugin

### DIFF
--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.cpp
@@ -142,7 +142,7 @@ void GPU_VolumeReconstructionWidget::on_startButton_clicked()
     std::cerr << "Constructing m_Reconstructor..." << std::endl;
 #endif
     m_VolumeReconstructor->SetNumberOfSlices( nbrOfSlices );
-	if (selectedUSAcquisitionObject->IsUsingMask())
+    if (ui->useMaskCheckBox->isChecked())
 	{
 		m_VolumeReconstructor->SetFixedSliceMask(selectedUSAcquisitionObject->GetMask());
 	}

--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.ui
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.ui
@@ -39,6 +39,19 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="useMaskCheckBox">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Use mask</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
The actual reconstruction plugin checks if the Acquisition has checkbox "use mask" checked or not to perform a masked/unmasked reconstruction. To modify the parameter, one needs to select Acquisition object and check/uncheck use mask. This commit adds the checkbox option in the plugin interface to avoid going back and forth between usReconstructionPlugin and USAcquisitionObject.