### PR TITLE
Allow all plugins to manage their objects when the NewScene or LoadScene are asked for.

### DIFF
--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -608,13 +608,3 @@ void IbisHardwareIGSIO::SceneFinishedLoading()
     StartConfig( m_lastIbisPlusConfigFile );
 }
 
-void IbisHardwareIGSIO::SceneAboutToSave()
-{
-
-}
-
-void IbisHardwareIGSIO::SceneFinishedSaving()
-{
-
-}
-

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -598,3 +598,23 @@ void IbisHardwareIGSIO::InternalWriteToolConfig(QString filename, Tool* tool)
 	writer0.Finish();
 }
 
+void IbisHardwareIGSIO::SceneAboutToLoad()
+{
+    this->ClearConfig();
+}
+
+void IbisHardwareIGSIO::SceneFinishedLoading()
+{
+    StartConfig( m_lastIbisPlusConfigFile );
+}
+
+void IbisHardwareIGSIO::SceneAboutToSave()
+{
+
+}
+
+void IbisHardwareIGSIO::SceneFinishedSaving()
+{
+
+}
+

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.h
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.h
@@ -76,6 +76,11 @@ public:
     virtual void AddTrackedVideoClient( TrackedSceneObject * obj ) override;
     virtual void RemoveTrackedVideoClient( TrackedSceneObject * obj) override;
 
+    virtual void SceneAboutToLoad();
+    virtual void SceneFinishedLoading();
+    virtual void SceneAboutToSave();
+    virtual void SceneFinishedSaving();
+
 private slots:
 
     void OpenSettingsWidget();

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.h
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.h
@@ -78,8 +78,6 @@ public:
 
     virtual void SceneAboutToLoad();
     virtual void SceneFinishedLoading();
-    virtual void SceneAboutToSave();
-    virtual void SceneFinishedSaving();
 
 private slots:
 

--- a/IbisLib/ibisplugin.h
+++ b/IbisLib/ibisplugin.h
@@ -41,6 +41,12 @@ public:
 
     virtual void Serialize( Serializer * ser ) {}
 
+    // Give plugin a chance to react before/after scene loading/saving
+    virtual void SceneAboutToLoad() {}
+    virtual void SceneFinishedLoading() {}
+    virtual void SceneAboutToSave() {}
+    virtual void SceneFinishedSaving() {}
+
 signals:
 
     void PluginModified();

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -346,10 +346,16 @@ void SceneManager::NewScene()
     SetRenderingEnabled( false );
     //Save current application settings
     Application::GetInstance().UpdateApplicationSettings();
+
+    NotifyPluginsSceneAboutToLoad();
+
     // Clear the scene
-    InternalClearScene();
+    this->ClearScene();
     //re-apply global ibis settings
     Application::GetInstance().ApplyApplicationSettings();
+
+    NotifyPluginsSceneFinishedLoading();
+
     SetRenderingEnabled( true );
     this->SetCurrentObject( this->GetSceneRoot() );
 }

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -347,14 +347,10 @@ void SceneManager::NewScene()
     //Save current application settings
     Application::GetInstance().UpdateApplicationSettings();
 
-    NotifyPluginsSceneAboutToLoad();
-
     // Clear the scene
     this->ClearScene();
     //re-apply global ibis settings
     Application::GetInstance().ApplyApplicationSettings();
-
-    NotifyPluginsSceneFinishedLoading();
 
     SetRenderingEnabled( true );
     this->SetCurrentObject( this->GetSceneRoot() );
@@ -1738,24 +1734,21 @@ void SceneManager::ObjectWriter( Serializer * ser )
 
 void SceneManager::NotifyPluginsSceneAboutToLoad()
 {
-    QList<ToolPluginInterface*> allTools;
-    Application::GetInstance().GetAllToolPlugins( allTools );
-    for( int i = 0; i < allTools.size(); ++i )
+    QList<IbisPlugin*> allPlugins;
+    Application::GetInstance().GetAllPlugins( allPlugins );
+    for( int i = 0; i < allPlugins.size(); ++i )
     {
-        ToolPluginInterface * toolModule = allTools[i];
-        toolModule->SceneAboutToLoad();
+        allPlugins[i]->SceneAboutToLoad();
     }
 }
 
 void SceneManager::NotifyPluginsSceneFinishedLoading()
 {
-    // Tell plugins new scene finished loading
-    QList<ToolPluginInterface*> allTools;
-    Application::GetInstance().GetAllToolPlugins( allTools );
-    for( int i = 0; i < allTools.size(); ++i )
+    QList<IbisPlugin*> allPlugins;
+    Application::GetInstance().GetAllPlugins( allPlugins );
+    for( int i = 0; i < allPlugins.size(); ++i )
     {
-        ToolPluginInterface * toolModule = allTools[i];
-        toolModule->SceneFinishedLoading();
+        allPlugins[i]->SceneFinishedLoading();
     }
 }
 

--- a/IbisLib/toolplugininterface.h
+++ b/IbisLib/toolplugininterface.h
@@ -61,12 +61,6 @@ public:
     // Returning false will cause the plugin not to close.
     virtual bool WidgetAboutToClose() { return true; }
 
-    // Give plugin a chance to react before/after scene loading/saving
-    virtual void SceneAboutToLoad() {}
-    virtual void SceneFinishedLoading() {}
-    virtual void SceneAboutToSave() {}
-    virtual void SceneFinishedSaving() {}
-    
 protected:
 
     virtual void PluginTypeLoadSettings( QSettings & s ) override;


### PR DESCRIPTION
That allows IbisHardwareIGSIO to restore tools with their models.