### PR TITLE
When saving scene do not copy MINC files, rather use the writer.

### DIFF
--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -1659,19 +1659,17 @@ void SceneManager::ObjectWriter( Serializer * ser )
             QFileInfo fi(obj->GetDataFileName());
             dataFileName.append(fi.completeSuffix());
             newPath.append(dataFileName);
-            if( !obj->IsA( "PointsObject" )) // from now on, we always save points in scene.xml
-            {
-                // Copy the object to the scene directory
-                if (!QFile::exists(newPath))
-                {
-                    QFile::copy(oldPath, newPath);
-                }
-            }
-            else
+            if( obj->IsA( "PointsObject" )) // from now on, we always save points in scene.xml
             {
                 obj->SetFullFileName("");
                 obj->SetDataFileName("");
                 newPath = QString("none");
+            }
+            else
+            {
+                // Copy the object to the scene directory
+                if (!QFile::exists(newPath))
+                    QFile::copy(oldPath, newPath);
             }
         }
         else

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -50,7 +50,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QPluginLoader>
-#include <QProcess>
 #include <QProgressDialog>
 #include <QApplication>
 
@@ -1665,14 +1664,7 @@ void SceneManager::ObjectWriter( Serializer * ser )
                 // Copy or move object to the scene directory
                 if (!QFile::exists(newPath))
                 {
-                    QString program("cp");
-                    QStringList arguments;
-                    arguments << "-p" << oldPath << newPath;
-                    QProcess *copyProcess = new QProcess(nullptr);
-                    copyProcess->start(program, arguments);
-                    if (copyProcess->waitForStarted())
-                        copyProcess->waitForFinished();
-                    delete copyProcess;
+                    QFile::copy(oldPath, newPath);
                 }
             }
             else if( obj->IsA( "ImageObject" ))

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -1659,19 +1659,13 @@ void SceneManager::ObjectWriter( Serializer * ser )
             QFileInfo fi(obj->GetDataFileName());
             dataFileName.append(fi.completeSuffix());
             newPath.append(dataFileName);
-            if( obj->IsA( "PolyDataObject" )) // from now on, we always save points in scene.xml
+            if( !obj->IsA( "PointsObject" )) // from now on, we always save points in scene.xml
             {
-                // Copy or move object to the scene directory
+                // Copy the object to the scene directory
                 if (!QFile::exists(newPath))
                 {
                     QFile::copy(oldPath, newPath);
                 }
-            }
-            else if( obj->IsA( "ImageObject" ))
-            {
-                ImageObject *img = ImageObject::SafeDownCast(obj);
-                Q_ASSERT( img );
-                img->SaveImageData( newPath );
             }
             else
             {

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -1657,11 +1657,11 @@ void SceneManager::ObjectWriter( Serializer * ser )
         dataFileName.append(".");
         if (!oldPath.isEmpty() && !obj->GetDataFileName().isEmpty())
         {
-            if( !obj->IsA( "PointsObject" )) // from now on, we always save points in scene.xml
+            QFileInfo fi(obj->GetDataFileName());
+            dataFileName.append(fi.completeSuffix());
+            newPath.append(dataFileName);
+            if( obj->IsA( "PolyDataObject" )) // from now on, we always save points in scene.xml
             {
-                QFileInfo fi(obj->GetDataFileName());
-                dataFileName.append(fi.completeSuffix());
-                newPath.append(dataFileName);
                 // Copy or move object to the scene directory
                 if (!QFile::exists(newPath))
                 {
@@ -1674,6 +1674,12 @@ void SceneManager::ObjectWriter( Serializer * ser )
                         copyProcess->waitForFinished();
                     delete copyProcess;
                 }
+            }
+            else if( obj->IsA( "ImageObject" ))
+            {
+                ImageObject *img = ImageObject::SafeDownCast(obj);
+                Q_ASSERT( img );
+                img->SaveImageData( newPath );
             }
             else
             {


### PR DESCRIPTION
This was done to fix the problem on Windows, where MINC files were not saved with the scene.