### PR TITLE
Clear calibration data when quitting camera calibration plugin.

### DIFF
--- a/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
@@ -169,7 +169,6 @@ void CameraCalibrationPluginInterface::SetCurrentCameraObjectId( int id )
     if( id != m_currentCameraObjectId )
     {
         m_currentCameraObjectId = id;
-        m_cameraCalibrator->ClearCalibrationData();
     }
     emit PluginModified();
 }

--- a/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
@@ -169,6 +169,7 @@ void CameraCalibrationPluginInterface::SetCurrentCameraObjectId( int id )
     if( id != m_currentCameraObjectId )
     {
         m_currentCameraObjectId = id;
+        m_cameraCalibrator->ClearCalibrationData();
     }
     emit PluginModified();
 }

--- a/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
@@ -97,6 +97,7 @@ bool CameraCalibrationPluginInterface::WidgetAboutToClose()
         m_cameraCalibrationWidget->close();
 
     ClearCameraViews();
+    m_cameraCalibrator->ClearCalibrationData();
     GetIbisAPI()->RemoveObject( m_calibrationGridObject );
 
     disconnect( GetIbisAPI(), SIGNAL(ObjectAdded(int)), this, SLOT(OnObjectAddedOrRemoved()) );

--- a/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
@@ -59,6 +59,7 @@ CameraCalibrationPluginInterface::~CameraCalibrationPluginInterface()
 {
     if( m_calibrationGridObject )
         m_calibrationGridObject->Delete();
+    m_cameraCalibrator->ClearCalibrationData();
     delete m_cameraCalibrator;
 }
 
@@ -97,7 +98,6 @@ bool CameraCalibrationPluginInterface::WidgetAboutToClose()
         m_cameraCalibrationWidget->close();
 
     ClearCameraViews();
-    m_cameraCalibrator->ClearCalibrationData();
     GetIbisAPI()->RemoveObject( m_calibrationGridObject );
 
     disconnect( GetIbisAPI(), SIGNAL(ObjectAdded(int)), this, SLOT(OnObjectAddedOrRemoved()) );

--- a/IbisPlugins/CameraCalibration/cameracalibrationsidepanelwidget.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationsidepanelwidget.cpp
@@ -107,17 +107,14 @@ void CameraCalibrationSidePanelWidget::UpdateUi()
     ui->viewListWidget->blockSignals( true );
     ui->viewListWidget->clear();
     CameraCalibrator * calib = m_pluginInterface->GetCameraCalibrator();
-    if( calib->GetNumberOfAccumulatedViews() > 0 )
+    for( int i = 0; i < calib->GetNumberOfAccumulatedViews(); ++i )
     {
-        for( int i = 0; i < calib->GetNumberOfViews(); ++i )
-        {
-            QString itemName = QString( "V%1 - %2" ).arg( i ).arg( calib->GetViewReprojectionError( i ) );
-            QListWidgetItem * item = new QListWidgetItem( itemName, ui->viewListWidget );
-            if( calib->IsViewEnabled( i ) )
-                item->setCheckState( Qt::Checked );
-            else
-                item->setCheckState( Qt::Unchecked );
-        }
+        QString itemName = QString( "V%1 - %2" ).arg( i ).arg( calib->GetViewReprojectionError( i ) );
+        QListWidgetItem * item = new QListWidgetItem( itemName, ui->viewListWidget );
+        if( calib->IsViewEnabled( i ) )
+            item->setCheckState( Qt::Checked );
+        else
+            item->setCheckState( Qt::Unchecked );
     }
     ui->viewListWidget->blockSignals( false );
 }

--- a/IbisPlugins/CameraCalibration/cameracalibrationsidepanelwidget.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationsidepanelwidget.cpp
@@ -107,14 +107,17 @@ void CameraCalibrationSidePanelWidget::UpdateUi()
     ui->viewListWidget->blockSignals( true );
     ui->viewListWidget->clear();
     CameraCalibrator * calib = m_pluginInterface->GetCameraCalibrator();
-    for( int i = 0; i < calib->GetNumberOfViews(); ++i )
+    if( calib->GetNumberOfAccumulatedViews() > 0 )
     {
-        QString itemName = QString( "V%1 - %2" ).arg( i ).arg( calib->GetViewReprojectionError( i ) );
-        QListWidgetItem * item = new QListWidgetItem( itemName, ui->viewListWidget );
-        if( calib->IsViewEnabled( i ) )
-            item->setCheckState( Qt::Checked );
-        else
-            item->setCheckState( Qt::Unchecked );
+        for( int i = 0; i < calib->GetNumberOfViews(); ++i )
+        {
+            QString itemName = QString( "V%1 - %2" ).arg( i ).arg( calib->GetViewReprojectionError( i ) );
+            QListWidgetItem * item = new QListWidgetItem( itemName, ui->viewListWidget );
+            if( calib->IsViewEnabled( i ) )
+                item->setCheckState( Qt::Checked );
+            else
+                item->setCheckState( Qt::Unchecked );
+        }
     }
     ui->viewListWidget->blockSignals( false );
 }


### PR DESCRIPTION
Fixes a crash that occured while using camera calibration plugin without camera in the scene.
Tested on Linux with and without camera, on Windows only without camera.