### PR TITLE
Fix internal vtk/itk image consistency in ImageObject

### DIFF
--- a/IbisLib/imageobject.h
+++ b/IbisLib/imageobject.h
@@ -60,7 +60,7 @@ public:
     bool SetItkLabelImage( IbisItkUnsignedChar3ImageType::Pointer image );  // for labels
     IbisItkFloat3ImageType::Pointer GetItkImage() { return this->ItkImage; }
     IbisItkUnsignedChar3ImageType::Pointer GetItkLabelImage() { return this->ItkLabelImage; }
-    void SetImage( vtkImageData * image );
+    void SetImage( vtkImageData * image, vtkTransform * tr=0 );
     
     // Implementation of parent virtual method
     virtual void ObjectAddedToScene() override;
@@ -122,6 +122,8 @@ protected:
     void Release3DRepresentation( View * view );
     void Setup2DRepresentation( int i, View * view );
     void Release2DRepresentation( int i, View * view );
+
+    void SetInternalImage(vtkImageData *);
 
 	// Lookup table management
     void SetLut(vtkSmartPointer<vtkScalarsToColors> lut);


### PR DESCRIPTION
This fix forces an ImageObject to use SetItkImage() when using SetImage(). 
* create a SetInternalImage() to set image object parameters from vtk image
* for itk image: in SetItkImage(), keeps the same pipeline but uses SetInternalImage() instead
* for vtk image: in SetImage(), converts vtk input image to Itk image and uses SetItkImage to set both images as above. This will force a conversion from vtk -> itk -> vtk (again) but ensures that both images have the same representations.

Is there a better/more optimized way to do that, what do you think?
