### PR TITLE
Feature: take US snapshot

### DIFF
--- a/IbisLib/gui/usprobeobjectsettingswidget.cpp
+++ b/IbisLib/gui/usprobeobjectsettingswidget.cpp
@@ -92,30 +92,37 @@ void UsProbeObjectSettingsWidget::UpdateToolStatus()
     case Ok:
         ui->probeStatusLabel->setText( "OK" );
         ui->probeStatusLabel->setStyleSheet( "background-color: lightGreen" );
+        ui->snapshotPushButton->setEnabled(true);
         break;
     case Missing:
         ui->probeStatusLabel->setText( "Missing" );
         ui->probeStatusLabel->setStyleSheet( "background-color: red" );
+        ui->snapshotPushButton->setEnabled(false);
         break;
     case OutOfVolume:
         ui->probeStatusLabel->setText( "Out of volume" );
         ui->probeStatusLabel->setStyleSheet( "background-color: yellow" );
+        ui->snapshotPushButton->setEnabled(true);
         break;
     case OutOfView:
         ui->probeStatusLabel->setText( "Out of view" );
         ui->probeStatusLabel->setStyleSheet( "background-color: red" );
+        ui->snapshotPushButton->setEnabled(false);
         break;
 	case HighError:
 		ui->probeStatusLabel->setText("High error");
 		ui->probeStatusLabel->setStyleSheet("background-color: red");
+        ui->snapshotPushButton->setEnabled(false);
 		break;
 	case Disabled:
 		ui->probeStatusLabel->setText("Disabled");
 		ui->probeStatusLabel->setStyleSheet("background-color: grey");
+        ui->snapshotPushButton->setEnabled(false);
 		break;
     case Undefined:
         ui->probeStatusLabel->setText( "Ultrasound probe not initialized" );
         ui->probeStatusLabel->setStyleSheet( "background-color: grey" );
+        ui->snapshotPushButton->setEnabled(false);
         break;
     }
 }
@@ -246,4 +253,11 @@ void UsProbeObjectSettingsWidget::OnCalibrationMatrixDialogClosed()
 {
     m_matrixDialog = 0;
     ui->calibrationMatrixPushButton->setChecked( false );
+}
+
+void UsProbeObjectSettingsWidget::on_snapshotPushButton_clicked()
+{
+    if (m_usProbeObject)
+        m_usProbeObject->TakeSnapshot();
+
 }

--- a/IbisLib/gui/usprobeobjectsettingswidget.h
+++ b/IbisLib/gui/usprobeobjectsettingswidget.h
@@ -51,6 +51,7 @@ private slots:
     void on_colorMapComboBox_currentIndexChanged(int index);
     void on_calibrationMatrixPushButton_toggled( bool on );
     void OnCalibrationMatrixDialogClosed();
+    void on_snapshotPushButton_clicked();
 
 private:
 

--- a/IbisLib/gui/usprobeobjectsettingswidget.ui
+++ b/IbisLib/gui/usprobeobjectsettingswidget.ui
@@ -46,6 +46,16 @@
     </layout>
    </item>
    <item>
+    <widget class="QPushButton" name="snapshotPushButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Snapshot</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="useMaskCheckBox">
      <property name="text">
       <string>Use Mask</string>

--- a/IbisLib/usprobeobject.cpp
+++ b/IbisLib/usprobeobject.cpp
@@ -74,6 +74,8 @@ bool UsProbeObject::CalibrationMatrixInfo::Serialize( Serializer * serializer )
 
 UsProbeObject::UsProbeObject()
 {
+    m_screenShotIndex = 0;
+
     this->SetCanChangeParent( false );
 
     m_currentCalibrationMatrixIndex = -1;
@@ -415,4 +417,25 @@ void UsProbeObject::UpdatePipeline()
         m_sliceStencil->SetInputConnection( m_constantPad->GetOutputPort() );
         m_actorInput->SetInputConnection( m_sliceStencil->GetOutputPort() );
     }
+}
+
+void UsProbeObject::TakeSnapshot()
+{
+    vtkSmartPointer<vtkTransform> transform = vtkTransform::New();
+    transform->SetMatrix(this->GetWorldTransform()->GetMatrix());
+    vtkSmartPointer<vtkImageData> image = vtkImageData::New();
+    image->DeepCopy(this->GetVideoOutput());
+    //if (this->GetUseMask())
+
+    QString name;
+    name.sprintf("US Screenshot %03d", m_screenShotIndex);
+
+    ImageObject * newObj = ImageObject::New();
+    newObj->SetName(name);
+    newObj->SetImage(image, transform);
+    newObj->Modified();
+
+    m_screenShotIndex++;
+
+    Application::GetInstance().GetSceneManager()->AddObject(newObj);
 }

--- a/IbisLib/usprobeobject.h
+++ b/IbisLib/usprobeobject.h
@@ -82,6 +82,8 @@ public:
     void SetCurrentLUTIndex( int index );
     int GetCurrentLUTIndex() { return m_lutIndex; }
 
+    void TakeSnapshot();
+
     struct CalibrationMatrixInfo
     {
         CalibrationMatrixInfo();
@@ -106,6 +108,8 @@ protected:
 
     bool m_maskOn;
     int m_lutIndex;
+    unsigned int m_screenShotIndex;
+
     vtkSmartPointer<vtkPassThrough>         m_videoInput;
     vtkSmartPointer<vtkPassThrough>         m_actorInput;
     USMask                 * m_mask;


### PR DESCRIPTION
Adds a feature to save ultrasound snapshots.
As this is a simple feature, I am not sure it was worth a plugin so I made it accessible from USProbeObject UI. The other option is to move it to the USAcquisitionPlugin.