### PR TITLE
Reference object change

### DIFF
--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -19,7 +19,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "vtkInteractorStyleTerrain.h"
 #include "vtkInteractorStyleJoystickCamera.h"
 #include "vtkTransform.h"
-#include "vtkLinearTransform.h"
 #include "vtkMultiImagePlaneWidget.h"
 #include "vtkImageData.h"
 #include "vtkAxes.h"
@@ -1019,6 +1018,10 @@ void SceneManager::SetReferenceDataObject( SceneObject *  refObject )
         if( m_referenceDataObject )
         {
             disconnect( m_referenceDataObject, SIGNAL(WorldTransformChangedSignal()), this, SLOT(ReferenceTransformChangedSlot()));
+            m_referenceTransform->Delete();
+            m_invReferenceTransform->Delete();
+            m_referenceTransform = vtkTransform::New();
+            m_invReferenceTransform = vtkTransform::New();
         }
         m_referenceDataObject = referenceObject;
         m_referenceTransform->Identity();
@@ -1363,7 +1366,7 @@ void SceneManager::ReferenceToWorld( double referencePoint[3], double worldPoint
     ImageObject * ref = GetReferenceDataObject();
     if( ref )
     {
-        vtkLinearTransform * transform = ref->GetWorldTransform();
+        vtkTransform * transform = ref->GetWorldTransform();
         transform->TransformPoint( referencePoint, worldPoint );
     }
     else

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -1018,12 +1018,16 @@ void SceneManager::SetReferenceDataObject( SceneObject *  refObject )
         if( m_referenceDataObject )
         {
             disconnect( m_referenceDataObject, SIGNAL(WorldTransformChangedSignal()), this, SLOT(ReferenceTransformChangedSlot()));
-            m_referenceTransform->Delete();
-            m_invReferenceTransform->Delete();
-            m_referenceTransform = vtkTransform::New();
-            m_invReferenceTransform = vtkTransform::New();
         }
         m_referenceDataObject = referenceObject;
+        // reset inputs and inverse flag
+        vtkSmartPointer<vtkTransform> tmp = vtkSmartPointer<vtkTransform>::New();
+        tmp->Identity();
+        m_referenceTransform->SetInput(tmp);
+        m_invReferenceTransform->SetInput(tmp);
+        if( m_invReferenceTransform->GetInverseFlag() )
+            m_invReferenceTransform->Inverse();
+
         m_referenceTransform->Identity();
         m_invReferenceTransform->Identity();
         if( m_referenceDataObject )

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -1020,11 +1020,7 @@ void SceneManager::SetReferenceDataObject( SceneObject *  refObject )
             disconnect( m_referenceDataObject, SIGNAL(WorldTransformChangedSignal()), this, SLOT(ReferenceTransformChangedSlot()));
         }
         m_referenceDataObject = referenceObject;
-        // reset inputs and inverse flag
-        vtkSmartPointer<vtkTransform> tmp = vtkSmartPointer<vtkTransform>::New();
-        tmp->Identity();
-        m_referenceTransform->SetInput(tmp);
-        m_invReferenceTransform->SetInput(tmp);
+        // reset inverse flag    
         if( m_invReferenceTransform->GetInverseFlag() )
             m_invReferenceTransform->Inverse();
 

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -532,9 +532,10 @@ void View::ReferenceTransformChanged()
         if( obj && this->Renderer )
         {
             vtkTransform * refTransform = obj->GetWorldTransform();
-            t->SetMatrix( this->PrevViewingTransform );
+            t->SetInput( refTransform );
+            t->Concatenate( this->PrevViewingTransform );
+
             cam->ApplyTransform( t );
-            cam->ApplyTransform( refTransform );
 
             // backup inverted current transform
             this->PrevViewingTransform->DeepCopy( refTransform->GetMatrix() );

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -532,10 +532,10 @@ void View::ReferenceTransformChanged()
         if( obj && this->Renderer )
         {
             vtkTransform * refTransform = obj->GetWorldTransform();
-            t->SetInput( refTransform );
-            t->Concatenate( this->PrevViewingTransform );
-
+            t->SetMatrix( this->PrevViewingTransform );
             cam->ApplyTransform( t );
+            NotifyNeedRender();
+            cam->ApplyTransform( refTransform );
 
             // backup inverted current transform
             this->PrevViewingTransform->DeepCopy( refTransform->GetMatrix() );

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -534,7 +534,6 @@ void View::ReferenceTransformChanged()
             vtkTransform * refTransform = obj->GetWorldTransform();
             t->SetMatrix( this->PrevViewingTransform );
             cam->ApplyTransform( t );
-            NotifyNeedRender();
             cam->ApplyTransform( refTransform );
 
             // backup inverted current transform


### PR DESCRIPTION
Do not concatenate transform, move the camera back to the initial position and then apply the transform of the new reference object.