### PR TITLE
Fixed crash in LandmarkRegistrationPluginInterface on exit

### DIFF
--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectplugininterface.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectplugininterface.cpp
@@ -26,7 +26,6 @@ LandmarkRegistrationObjectPluginInterface::LandmarkRegistrationObjectPluginInter
 
 LandmarkRegistrationObjectPluginInterface::~LandmarkRegistrationObjectPluginInterface()
 {
-    this->Clear();
 }
 
 SceneObject *LandmarkRegistrationObjectPluginInterface::CreateObject()


### PR DESCRIPTION
SceneManager is deleted before the plugins, all the objects were removed, call to LandmarkRegistrationPluginInterface::Clear() caused crash.