### PR TITLE
Save pointer position

### DIFF
--- a/IbisLib/gui/pointerobjectsettingsdialog.cpp
+++ b/IbisLib/gui/pointerobjectsettingsdialog.cpp
@@ -80,6 +80,7 @@ void PointerObjectSettingsDialog::on_savePositionPushButton_clicked()
             m_pointerPickedPointsObject->MoveCursorToPoint( index );
         if (delayAddObject)
             m_pointer->ManagerAddPointerPickedPointsObject();
+		this->UpdateUI();
     }
 }
 

--- a/IbisLib/gui/pointerobjectsettingsdialog.cpp
+++ b/IbisLib/gui/pointerobjectsettingsdialog.cpp
@@ -16,6 +16,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "pointercalibrationdialog.h"
 #include "vtkQtMatrixDialog.h"
 #include "vtkTransform.h"
+#include "scenemanager.h"
 
 PointerObjectSettingsDialog::PointerObjectSettingsDialog(QWidget *parent) :
     QWidget(parent),
@@ -74,7 +75,9 @@ void PointerObjectSettingsDialog::on_savePositionPushButton_clicked()
         double *pos = m_pointer->GetTipPosition();
         int index = m_pointerPickedPointsObject->GetNumberOfPoints();
         m_pointerPickedPointsObject->AddPoint(QString::number(index+1), pos);
-        m_pointerPickedPointsObject->MoveCursorToPoint( index );
+        SceneManager *manager = m_pointer->GetManager();
+        if( manager->GetReferenceDataObject() ) // we can only move cursor if cut planes are displayed
+            m_pointerPickedPointsObject->MoveCursorToPoint( index );
         if (delayAddObject)
             m_pointer->ManagerAddPointerPickedPointsObject();
     }

--- a/IbisLib/gui/pointerobjectsettingsdialog.cpp
+++ b/IbisLib/gui/pointerobjectsettingsdialog.cpp
@@ -76,10 +76,10 @@ void PointerObjectSettingsDialog::on_savePositionPushButton_clicked()
         int index = m_pointerPickedPointsObject->GetNumberOfPoints();
         m_pointerPickedPointsObject->AddPoint(QString::number(index+1), pos);
         SceneManager *manager = m_pointer->GetManager();
-        if( manager->GetReferenceDataObject() ) // we can only move cursor if cut planes are displayed
-            m_pointerPickedPointsObject->MoveCursorToPoint( index );
         if (delayAddObject)
-            m_pointer->ManagerAddPointerPickedPointsObject();
+			m_pointer->ManagerAddPointerPickedPointsObject();
+		if (manager->GetReferenceDataObject()) // we can only move cursor if cut planes are displayed
+			m_pointerPickedPointsObject->MoveCursorToPoint(index);
 		this->UpdateUI();
     }
 }


### PR DESCRIPTION
I fixed the crash when points are picked in an empty scene, or scene containing surfaces only - no cut planes in any view.