### PR TITLE
Camera object non isotropic focal

### DIFF
--- a/IbisLib/cameraobject.cpp
+++ b/IbisLib/cameraobject.cpp
@@ -499,6 +499,19 @@ void CameraObject::SetGlobalOpacity( double opacity )
     emit ParamsModified();
 }
 
+void CameraObject::SetFocalPix( double fx, double fy )
+{
+    m_intrinsicParams.m_focal[0] = fx / GetImageWidth();
+    m_intrinsicParams.m_focal[1] = fy / GetImageHeight();
+    UpdateGeometricRepresentation();
+}
+
+void CameraObject::GetFocalPix( double & x, double & y )
+{
+    x = m_intrinsicParams.m_focal[0] * GetImageWidth();
+    y = m_intrinsicParams.m_focal[1] * GetImageHeight();
+}
+
 void CameraObject::SetImageCenterPix( double x, double y )
 {
     m_intrinsicParams.m_center[0] = x / GetImageWidth();
@@ -510,12 +523,6 @@ void CameraObject::GetImageCenterPix( double & x, double & y )
 {
     x = m_intrinsicParams.m_center[0] * GetImageWidth();
     y = m_intrinsicParams.m_center[1] * GetImageHeight();
-}
-
-void CameraObject::GetFocalPix( double & x, double & y )
-{
-    x = m_intrinsicParams.m_focal[0] * GetImageWidth();
-    y = m_intrinsicParams.m_focal[1] * GetImageHeight();
 }
 
 void CameraObject::SetLensDistortion( double dist )

--- a/IbisLib/cameraobject.cpp
+++ b/IbisLib/cameraobject.cpp
@@ -1064,10 +1064,10 @@ void CameraObject::UpdateGeometricRepresentation()
     }
     m_camera->SetViewAngle( m_intrinsicParams.GetVerticalAngleDegrees() );
 
-    double angleRad = 0.5 * m_intrinsicParams.GetVerticalAngleRad();
-    double offsetY = m_imageDistance * tan( angleRad );
-    double offsetX = width / ((double)height) * offsetY;
-    double scaleFactor = ( 2 * offsetY ) / height;
+    double offsetY = m_imageDistance * 0.5 / m_intrinsicParams.m_focal[1];
+    double offsetX = m_imageDistance * 0.5 / m_intrinsicParams.m_focal[0];
+    double scaleFactorX = 2.0 * offsetX / static_cast<double>(width);
+    double scaleFactorY = 2.0 * offsetY / static_cast<double>(height);
 
     vtkPoints * pts = m_cameraPolyData->GetPoints();
     pts->SetPoint( 1, -offsetX, -offsetY, -m_imageDistance );
@@ -1078,7 +1078,7 @@ void CameraObject::UpdateGeometricRepresentation()
 
     m_imageTransform->Identity();
     m_imageTransform->Translate( -offsetX, -offsetY, -m_imageDistance );
-    m_imageTransform->Scale( scaleFactor, scaleFactor, scaleFactor );
+    m_imageTransform->Scale( scaleFactorX, scaleFactorY, 1.0 );
 
     m_cachedImageSize[ 0 ] = width;
     m_cachedImageSize[ 1 ] = height;

--- a/IbisLib/cameraobject.h
+++ b/IbisLib/cameraobject.h
@@ -102,9 +102,10 @@ public:
     double GetImageDistance() { return m_imageDistance; }
     double GetGlobalOpacity() { return m_globalOpacity; }
     void SetGlobalOpacity( double opacity );
+    void SetFocalPix( double fx, double fy );
+    void GetFocalPix( double & fx, double & fy );
     void SetImageCenterPix( double x, double y );
     void GetImageCenterPix( double & x, double & y );
-    void GetFocalPix( double & x, double & y );
     double GetLensDistortion() { return m_intrinsicParams.m_distorsionK1; }
     void SetLensDistortion( double x );
     double GetLensDisplacement();

--- a/IbisLib/gui/cameraobjectsettingswidget.cpp
+++ b/IbisLib/gui/cameraobjectsettingswidget.cpp
@@ -102,8 +102,8 @@ void CameraObjectSettingsWidget::UpdateUI()
     ui->imageDistanceSpinBox->setValue( m_camera->GetImageDistance() );
     ui->imageDistanceSpinBox->blockSignals( false );
 
-    ui->xFocalLineEdit->setText( QString::number( m_camera->GetIntrinsicParams().m_focal[0], 'f', 2 ) );
-    ui->yFocalLineEdit->setText( QString::number( m_camera->GetIntrinsicParams().m_focal[1], 'f', 2 ) );
+    //ui->xFocalLineEdit->setText( QString::number( m_camera->GetIntrinsicParams().m_focal[0], 'f', 2 ) );
+    //ui->yFocalLineEdit->setText( QString::number( m_camera->GetIntrinsicParams().m_focal[1], 'f', 2 ) );
 
     double center[2] = { 0.0, 0.0 };
     m_camera->GetImageCenterPix( center[0], center[1] );
@@ -343,6 +343,16 @@ void CameraObjectSettingsWidget::on_showMaskCheckBox_toggled(bool checked)
     m_camera->SetShowMask( checked );
 }
 
+void CameraObjectSettingsWidget::on_fxSpinBox_valueChanged(double arg1)
+{
+    Q_ASSERT( m_camera );
+}
+
+void CameraObjectSettingsWidget::on_fySpinBox_valueChanged(double arg1)
+{
+    Q_ASSERT( m_camera );
+}
+
 void CameraObjectSettingsWidget::on_xImageCenterSpinBox_valueChanged(double arg1)
 {
     Q_ASSERT( m_camera );
@@ -398,32 +408,32 @@ void CameraObjectSettingsWidget::on_extrinsicParamsGroupBox_toggled(bool arg1)
     UpdateUI();
 }
 
-void CameraObjectSettingsWidget::on_xtransSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_xtransSpinBox_valueChanged(double )
 {
     UpdateExtrinsicTransform();
 }
 
-void CameraObjectSettingsWidget::on_ytransSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_ytransSpinBox_valueChanged(double )
 {
     UpdateExtrinsicTransform();
 }
 
-void CameraObjectSettingsWidget::on_ztransSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_ztransSpinBox_valueChanged(double )
 {
     UpdateExtrinsicTransform();
 }
 
-void CameraObjectSettingsWidget::on_xrotSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_xrotSpinBox_valueChanged(double )
 {
     UpdateExtrinsicTransform();
 }
 
-void CameraObjectSettingsWidget::on_yrotSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_yrotSpinBox_valueChanged(double )
 {
     UpdateExtrinsicTransform();
 }
 
-void CameraObjectSettingsWidget::on_zrotSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_zrotSpinBox_valueChanged(double )
 {
     UpdateExtrinsicTransform();
 }
@@ -484,3 +494,4 @@ void CameraObjectSettingsWidget::on_lensDisplacementSpinBox_valueChanged(double 
     m_camera->SetLensDisplacement( arg1 );
     UpdateUI();
 }
+

--- a/IbisLib/gui/cameraobjectsettingswidget.cpp
+++ b/IbisLib/gui/cameraobjectsettingswidget.cpp
@@ -94,17 +94,28 @@ void CameraObjectSettingsWidget::UpdateUI()
         }
     }
 
+    // Vertical angle (function of focals)
     ui->verticalAngleSpinBox->blockSignals( true );
     ui->verticalAngleSpinBox->setValue( m_camera->GetVerticalAngleDegrees() );
     ui->verticalAngleSpinBox->blockSignals( false );
 
+    // Image distance
     ui->imageDistanceSpinBox->blockSignals( true );
     ui->imageDistanceSpinBox->setValue( m_camera->GetImageDistance() );
     ui->imageDistanceSpinBox->blockSignals( false );
 
-    //ui->xFocalLineEdit->setText( QString::number( m_camera->GetIntrinsicParams().m_focal[0], 'f', 2 ) );
-    //ui->yFocalLineEdit->setText( QString::number( m_camera->GetIntrinsicParams().m_focal[1], 'f', 2 ) );
+    // Focal
+    double fx, fy;
+    m_camera->GetFocalPix(fx,fy);
+    ui->fxSpinBox->blockSignals( true );
+    ui->fxSpinBox->setValue( fx );
+    ui->fxSpinBox->blockSignals( false );
 
+    ui->fySpinBox->blockSignals( true );
+    ui->fySpinBox->setValue( fy );
+    ui->fySpinBox->blockSignals( false );
+
+    // Image center
     double center[2] = { 0.0, 0.0 };
     m_camera->GetImageCenterPix( center[0], center[1] );
 
@@ -343,17 +354,23 @@ void CameraObjectSettingsWidget::on_showMaskCheckBox_toggled(bool checked)
     m_camera->SetShowMask( checked );
 }
 
-void CameraObjectSettingsWidget::on_fxSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_fxSpinBox_valueChanged(double )
 {
     Q_ASSERT( m_camera );
+    double fx = ui->fxSpinBox->value();
+    double fy = ui->fySpinBox->value();
+    m_camera->SetFocalPix( fx, fy );
 }
 
-void CameraObjectSettingsWidget::on_fySpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_fySpinBox_valueChanged(double )
 {
     Q_ASSERT( m_camera );
+    double fx = ui->fxSpinBox->value();
+    double fy = ui->fySpinBox->value();
+    m_camera->SetFocalPix( fx, fy );
 }
 
-void CameraObjectSettingsWidget::on_xImageCenterSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_xImageCenterSpinBox_valueChanged(double)
 {
     Q_ASSERT( m_camera );
     double x = ui->xImageCenterSpinBox->value();
@@ -361,7 +378,7 @@ void CameraObjectSettingsWidget::on_xImageCenterSpinBox_valueChanged(double arg1
     m_camera->SetImageCenterPix( x, y );
 }
 
-void CameraObjectSettingsWidget::on_yImageCenterSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_yImageCenterSpinBox_valueChanged(double)
 {
     Q_ASSERT( m_camera );
     double x = ui->xImageCenterSpinBox->value();
@@ -369,7 +386,7 @@ void CameraObjectSettingsWidget::on_yImageCenterSpinBox_valueChanged(double arg1
     m_camera->SetImageCenterPix( x, y );
 }
 
-void CameraObjectSettingsWidget::on_distortionSpinBox_valueChanged(double arg1)
+void CameraObjectSettingsWidget::on_distortionSpinBox_valueChanged(double)
 {
     Q_ASSERT( m_camera );
     double dist = ui->distortionSpinBox->value();

--- a/IbisLib/gui/cameraobjectsettingswidget.h
+++ b/IbisLib/gui/cameraobjectsettingswidget.h
@@ -58,6 +58,8 @@ private slots:
     void on_calibrationMatrixButton_toggled( bool checked);
     void CalibrationMatrixDialogClosed();
 
+    void on_fxSpinBox_valueChanged(double arg1);
+    void on_fySpinBox_valueChanged(double arg1);
     void on_xImageCenterSpinBox_valueChanged(double arg1);
     void on_yImageCenterSpinBox_valueChanged(double arg1);
     void on_distortionSpinBox_valueChanged(double arg1);

--- a/IbisLib/gui/cameraobjectsettingswidget.ui
+++ b/IbisLib/gui/cameraobjectsettingswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>319</width>
-    <height>883</height>
+    <height>979</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -247,9 +247,9 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_14">
+       <layout class="QHBoxLayout" name="horizontalLayout_22">
         <item>
-         <widget class="QLabel" name="label_8">
+         <widget class="QLabel" name="fxLabel">
           <property name="maximumSize">
            <size>
             <width>20</width>
@@ -262,14 +262,20 @@
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="xFocalLineEdit">
-          <property name="readOnly">
-           <bool>true</bool>
+         <widget class="QDoubleSpinBox" name="fxSpinBox">
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="label_9">
+         <widget class="QLabel" name="fyLabel">
           <property name="maximumSize">
            <size>
             <width>20</width>
@@ -282,9 +288,15 @@
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="yFocalLineEdit">
-          <property name="readOnly">
-           <bool>true</bool>
+         <widget class="QDoubleSpinBox" name="fySpinBox">
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
          </widget>
         </item>

--- a/IbisLib/gui/cameraobjectsettingswidget.ui
+++ b/IbisLib/gui/cameraobjectsettingswidget.ui
@@ -263,11 +263,14 @@
         </item>
         <item>
          <widget class="QDoubleSpinBox" name="fxSpinBox">
+          <property name="toolTip">
+           <string>Horizontal focal distance (pixels)</string>
+          </property>
           <property name="minimum">
            <double>0.000000000000000</double>
           </property>
           <property name="maximum">
-           <double>100.000000000000000</double>
+           <double>100000.000000000000000</double>
           </property>
           <property name="singleStep">
            <double>0.100000000000000</double>
@@ -289,11 +292,14 @@
         </item>
         <item>
          <widget class="QDoubleSpinBox" name="fySpinBox">
+          <property name="toolTip">
+           <string>Vertical focal distance (pixels)</string>
+          </property>
           <property name="minimum">
            <double>0.000000000000000</double>
           </property>
           <property name="maximum">
-           <double>100.000000000000000</double>
+           <double>100000.000000000000000</double>
           </property>
           <property name="singleStep">
            <double>0.100000000000000</double>
@@ -319,6 +325,9 @@
         </item>
         <item>
          <widget class="QDoubleSpinBox" name="xImageCenterSpinBox">
+          <property name="toolTip">
+           <string>x coordinate of image center</string>
+          </property>
           <property name="minimum">
            <double>-10000.000000000000000</double>
           </property>
@@ -345,6 +354,9 @@
         </item>
         <item>
          <widget class="QDoubleSpinBox" name="yImageCenterSpinBox">
+          <property name="toolTip">
+           <string>y coordinate of image center</string>
+          </property>
           <property name="minimum">
            <double>-10000.000000000000000</double>
           </property>
@@ -374,6 +386,9 @@
             <width>120</width>
             <height>16777215</height>
            </size>
+          </property>
+          <property name="toolTip">
+           <string>K1 lens distortion coefficient</string>
           </property>
           <property name="correctionMode">
            <enum>QAbstractSpinBox::CorrectToNearestValue</enum>

--- a/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.cpp
@@ -110,6 +110,8 @@ void CameraCalibrationPluginInterface::LoadSettings( QSettings & s )
     m_calibrationGridWidth = s.value( "CalibrationGridWidth", 6 ).toInt();
     m_calibrationGridHeight = s.value( "CalibrationGridHeight", 8 ).toInt();
     m_calibrationGridCellSize = s.value( "CalibrationGridCellSize", 30.0 ).toDouble();
+    bool optimizeGridDetection = s.value( "OptimizeGridDetection", false ).toBool();
+    m_cameraCalibrator->SetOptimizeGridDetection( optimizeGridDetection );
 }
 
 void CameraCalibrationPluginInterface::SaveSettings( QSettings & s )
@@ -117,6 +119,7 @@ void CameraCalibrationPluginInterface::SaveSettings( QSettings & s )
     s.setValue( "CalibrationGridWidth", m_calibrationGridWidth );
     s.setValue( "CalibrationGridHeight", m_calibrationGridHeight );
     s.setValue( "CalibrationGridCellSize", m_calibrationGridCellSize );
+    s.setValue( "OptimizeGridDetection", m_cameraCalibrator->GetOptimizeGridDetection() );
 }
 
 void CameraCalibrationPluginInterface::StartCalibrationWidget( bool on )
@@ -246,6 +249,16 @@ void CameraCalibrationPluginInterface::CancelAccumulation()
 {
     m_isAccumulating = false;
     m_cameraCalibrator->ClearAccumulatedViews();
+}
+
+bool CameraCalibrationPluginInterface::GetOptimizeGridDetection()
+{
+    return m_cameraCalibrator->GetOptimizeGridDetection();
+}
+
+void CameraCalibrationPluginInterface::SetOptimizeGridDetection( bool optimize )
+{
+    m_cameraCalibrator->SetOptimizeGridDetection( optimize );
 }
 
 void CameraCalibrationPluginInterface::ImportCalibrationData( QString dir )

--- a/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.h
+++ b/IbisPlugins/CameraCalibration/cameracalibrationplugininterface.h
@@ -87,6 +87,8 @@ public:
     int GetNumberOfAccumulatedViews();
     int GetNumberOfViewsToAccumulate();
     void CancelAccumulation();
+    bool GetOptimizeGridDetection();
+    void SetOptimizeGridDetection( bool optimize );
 
     // Do Calibration
     void ImportCalibrationData( QString dir );

--- a/IbisPlugins/CameraCalibration/cameracalibrationwidget.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationwidget.cpp
@@ -401,3 +401,9 @@ void CameraCalibrationWidget::on_bothRadioButton_toggled(bool checked)
         m_pluginInterface->SetComputeIntrinsic( true );
     }
 }
+
+void CameraCalibrationWidget::on_optimizeGridDetectCheckBox_toggled(bool checked)
+{
+    Q_ASSERT( m_pluginInterface );
+    m_pluginInterface->SetOptimizeGridDetection( checked );
+}

--- a/IbisPlugins/CameraCalibration/cameracalibrationwidget.h
+++ b/IbisPlugins/CameraCalibration/cameracalibrationwidget.h
@@ -57,6 +57,8 @@ private slots:
     void on_captureViewButton_clicked();
     void on_clearCalibrationViewsButton_clicked();
 
+    void on_optimizeGridDetectCheckBox_toggled(bool checked);
+
 private:
 
     vtkRenderWindow * GetRenderWindow();

--- a/IbisPlugins/CameraCalibration/cameracalibrationwidget.ui
+++ b/IbisPlugins/CameraCalibration/cameracalibrationwidget.ui
@@ -201,6 +201,25 @@
       </widget>
      </item>
      <item>
+      <widget class="QGroupBox" name="gridDetectionGroupBox">
+       <property name="title">
+        <string>Grid detection</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="optimizeGridDetectCheckBox">
+          <property name="toolTip">
+           <string>If checked, input image is downsized before detecting grid to speed up detection. This is only useful with large resolution images</string>
+          </property>
+          <property name="text">
+           <string>Optimize</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QTextEdit" name="calibrationResultTextEdit">
        <property name="readOnly">
         <bool>true</bool>

--- a/IbisPlugins/CameraCalibration/cameracalibrator.h
+++ b/IbisPlugins/CameraCalibration/cameracalibrator.h
@@ -53,6 +53,8 @@ public:
     double GetGridCellSize() { return m_gridCellSize; }
 
     // Do calibration and manage data
+    bool GetOptimizeGridDetection();
+    void SetOptimizeGridDetection( bool optimize );
     void ClearCalibrationData();
     void ExportCalibrationData( QString dirName, QProgressDialog * progressDlg );
     void ImportCalibrationData( QString dirName, QProgressDialog * progressDlg );
@@ -94,6 +96,7 @@ protected:
     double m_gridCellSize;
 
     // Calibration data
+    bool m_optimizeGridDetection;
     std::vector<cv::Point3f>  m_objectPointsOneView;
     std::vector<bool> m_viewEnabled;
     std::vector< std::vector<cv::Point3f> > m_objectPoints;


### PR DESCRIPTION
* Before, camera object was assuming the x and y focal where the same. Now, CameraObject can display focal length that are different in x and y.

*  Downsizing images for calibration grid detection can now be turned off (and is off by default)