### PR TITLE
Add timestamp to TrackedSceneObject

### DIFF
--- a/IbisHardware/tracker.cpp
+++ b/IbisHardware/tracker.cpp
@@ -769,6 +769,7 @@ void Tracker::PushTrackerStateToSceneObjects()
             }
             else
                 m_toolVec[i].sceneObject->SetState( GetToolState( i ) );
+            m_toolVec[i].sceneObject->SetTimestamp( GetTool(i)->GetTimeStamp() );
         }
     }
 }

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -171,6 +171,7 @@ void IbisHardwareIGSIO::Update()
                 igtlioTransformDevice * transformDevice = igtlioTransformDevice::SafeDownCast( tool->transformDevice );
                 tool->sceneObject->SetInputMatrix( transformDevice->GetContent().transform );
             }
+            tool->sceneObject->SetTimestamp( tool->transformDevice->GetTimestamp() );
             tool->sceneObject->SetState( ComputeToolStatus( tool->transformDevice, tool ) );
         }
         if( tool->imageDevice )

--- a/IbisLib/trackedsceneobject.cpp
+++ b/IbisLib/trackedsceneobject.cpp
@@ -12,6 +12,7 @@ ObjectSerializationMacro( TrackedSceneObject );
 
 TrackedSceneObject::TrackedSceneObject()
 {
+    m_timestamp = -1;
     m_hardwareModule = nullptr;
     m_state = Undefined;
     m_transform = vtkTransform::New();

--- a/IbisLib/trackedsceneobject.h
+++ b/IbisLib/trackedsceneobject.h
@@ -43,11 +43,13 @@ public:
     void SetInputTransform( vtkTransform * t );
     vtkTransform * GetUncalibratedTransform() { return m_transform; }
     void SetCalibrationMatrix( vtkMatrix4x4 * mat );
+    void SetTimestamp(double timestamp) { (timestamp < 0) ? m_timestamp = -1 : m_timestamp = timestamp; }
     vtkMatrix4x4 * GetCalibrationMatrix();
 
     vtkTransform * GetCalibrationTransform() { return m_calibrationTransform; }
     vtkTransform * GetUncalibratedWorldTransform() { return m_uncalibratedWorldTransform; }
     vtkTransform * GetReferenceToolTransform();
+    double GetLastTimestamp() { return m_timestamp; }
 
     bool IsTransformFrozen();
     void FreezeTransform();
@@ -67,6 +69,8 @@ protected:
     vtkTransform * m_transform;
     vtkTransform * m_calibrationTransform;
     vtkTransform * m_uncalibratedWorldTransform;
+
+    double m_timestamp;
 };
 
 ObjectSerializationHeaderMacro( TrackedSceneObject );


### PR DESCRIPTION
Add timestamp to tracked tools (see issue #309). Invalid timestamps are init to -1.