### PR TITLE
Check message direction before requesting timestamp

### DIFF
--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -171,7 +171,8 @@ void IbisHardwareIGSIO::Update()
                 igtlioTransformDevice * transformDevice = igtlioTransformDevice::SafeDownCast( tool->transformDevice );
                 tool->sceneObject->SetInputMatrix( transformDevice->GetContent().transform );
             }
-            tool->sceneObject->SetTimestamp( tool->transformDevice->GetTimestamp() );
+            if (tool->transformDevice->MessageDirectionIsIn() == igtlioTransformDevice::MESSAGE_DIRECTION_IN)
+                tool->sceneObject->SetTimestamp(tool->transformDevice->GetTimestamp());
             tool->sceneObject->SetState( ComputeToolStatus( tool->transformDevice, tool ) );
         }
         if( tool->imageDevice )


### PR DESCRIPTION
Requesting a timestamp on windows caused a crash. igtlioTransformDevice::ReceiveIGTLMessage was called with an empty buffer. I added a check for message direction to request timestamps on received messages only. 
I am not sure why this fixes the bug. I thought [IbisHardwareIGSIO::Update()](https://github.com/IbisNeuronav/Ibis/blob/b2e843244e0edd5a0f19b361f234e9754559c1f1/IbisHardwareIGSIO/ibishardwareIGSIO.cpp#L154) was only called when _receiving_ new messages?