### PR TITLE
Restore CameraObject properly when loading scene

### DIFF
--- a/IbisLib/cameraobject.h
+++ b/IbisLib/cameraobject.h
@@ -110,14 +110,14 @@ public:
     void SetLensDistortion( double x );
     double GetLensDisplacement();
     void SetLensDisplacement( double d );
-    bool IsTransparencyCenterTracked() { return m_trackedTransparencyCenter; }
+    bool IsTransparencyCenterTracked() { return m_trackTargetTransparencyCenter; }
     void SetTransparencyCenterTracked( bool t );
     void SetTransparencyCenter( double x, double y );
     bool IsUsingTransparency() { return m_useTransparency; }
     void SetUseTransparency( bool use );
-    bool IsUsingGradient() { return m_useGradient; }
+    bool IsUsingGradient() { return m_useGradientTargetTransparencyModulation; }
     void SetUseGradient( bool use );
-    bool IsShowingMask() { return m_showMask; }
+    bool IsShowingMask() { return m_showTargetTransparencyMask; }
     void SetShowMask( bool show );
     double GetSaturation() { return m_saturation; }
     void SetSaturation( double s );
@@ -169,12 +169,16 @@ protected:
 
     void ListenForIbisClockTick( bool listen );
     void InternalDrawPath( std::vector< Vec3 > & p3d, double color[4] );
+
+    // Base classes overrides
     virtual void Hide() override;
     virtual void Show() override;
-
     virtual void ObjectAddedToScene() override;
     virtual void ObjectAboutToBeRemovedFromScene() override;
+    virtual void InternalPostSceneRead() override;
+
     void InternalSetIntrinsicParams();
+    void InternalSetTrackCamera();
     void UpdateGeometricRepresentation();
     void UpdateVtkCamera();
     vtkRenderer * GetCurrentRenderer( View * v );
@@ -210,9 +214,9 @@ protected:
     double m_saturation;
     double m_brightness;
     bool m_useTransparency;
-    bool m_useGradient;
-    bool m_showMask;
-    bool m_trackedTransparencyCenter;
+    bool m_useGradientTargetTransparencyModulation;
+    bool m_showTargetTransparencyMask;
+    bool m_trackTargetTransparencyCenter;
     double m_transparencyCenter[2];
     double m_transparencyRadius[2];
     bool m_mouseMovingTransparency;

--- a/IbisLib/trackedvideobuffer.cpp
+++ b/IbisLib/trackedvideobuffer.cpp
@@ -122,19 +122,26 @@ bool TrackedVideoBuffer::Serialize( Serializer * ser, QString dataDirectory )
 {
     ::Serialize( ser, "CurrentFrame", m_currentFrame );
 
-    if( !ser->IsReader() )
-        WriteMatrices( m_matrices, dataDirectory );
-    else
-        ReadMatrices( m_matrices, dataDirectory );
+    // If we are writing and dir already exists, sequence has been saved so we can skip writing
+    // todo: find smarter way to handle this
+    QFileInfo info(dataDirectory);
+    bool needsSerialization = !( !ser->IsReader() && info.exists() && info.isDir() );
 
-    if( !ser->IsReader() )
-        WriteImages( dataDirectory );
-    else
-        ReadImages( m_matrices.size(), dataDirectory );
+    if( needsSerialization )
+    {
+        if( !ser->IsReader() )
+            WriteMatrices( m_matrices, dataDirectory );
+        else
+            ReadMatrices( m_matrices, dataDirectory );
 
-    if( ser->IsReader() )
-        if( m_currentFrame != -1 )
-            SetCurrentFrame( m_currentFrame );
+        if( !ser->IsReader() )
+            WriteImages( dataDirectory );
+        else
+            ReadImages( m_matrices.size(), dataDirectory );
+    }
+
+    if( ser->IsReader() && m_currentFrame != -1 )
+        SetCurrentFrame( m_currentFrame );
 
     return true;
 }

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -327,14 +327,14 @@ void View::TakeControl( ViewController * c )
     }
 
     CurrentController = c;
-    this->Interactor->SetInteractorStyle( 0 );
+    this->Interactor->SetInteractorStyle( nullptr );
 }
 
 void View::ReleaseControl( ViewController * c )
 {
     Q_ASSERT( CurrentController == c );
 
-    CurrentController = 0;
+    CurrentController = nullptr;
     this->Interactor->SetInteractorStyle( this->InteractorStyle );
 }
 


### PR DESCRIPTION
* When AR view is ON, restore this state properly when scene is loaded

* Save CameraObject settings (Image distance, global opacity, saturation, brightness and target transparency properties) in scene