### PR TITLE
Using std::string instead of char[] to check file header

### DIFF
--- a/IbisVTK/vtkMNI/vtkXFMReader.cxx
+++ b/IbisVTK/vtkMNI/vtkXFMReader.cxx
@@ -152,10 +152,10 @@ int vtkXFMReader::CanReadFile( const char * fname )
         return 0;
     }
     
-    char fileType[30];
-    f.getline( fileType, 30 );
+    std::string fileType;
+    std::getline( f, fileType);
     f.close();
-    if( strcmp( fileType, "MNI Transform File" ) != 0 )
+    if( fileType.find( "MNI Transform File" ) == std::string::npos )
     {
         vtkErrorMacro( << "This is not MNI XFM type file." << endl );
         return 0;


### PR DESCRIPTION
When saving .xfm files on Windows the header gets "\r" at the end of the first line which is not recognized by strcmp()