### PR TITLE
Record tracking plugin

### DIFF
--- a/IbisPlugins/RecordTracking/CMakeLists.txt
+++ b/IbisPlugins/RecordTracking/CMakeLists.txt
@@ -1,0 +1,7 @@
+# define sources
+set( PluginSrc recordtrackingplugininterface.cpp recordtrackingwidget.cpp )
+set( PluginHdrMoc recordtrackingwidget.h recordtrackingplugininterface.h )
+set( PluginUi recordtrackingwidget.ui )
+
+# Create plugin
+DefinePlugin( "${PluginSrc}" "${PluginHdr}" "${PluginHdrMoc}" "${PluginUi}" )

--- a/IbisPlugins/RecordTracking/declare-plugin.cmake
+++ b/IbisPlugins/RecordTracking/declare-plugin.cmake
@@ -1,0 +1,1 @@
+DeclarePlugin( RecordTracking NO DESCRIPTION "Record trakced tools" )

--- a/IbisPlugins/RecordTracking/recordtrackingplugininterface.cpp
+++ b/IbisPlugins/RecordTracking/recordtrackingplugininterface.cpp
@@ -1,0 +1,68 @@
+/*=========================================================================
+Ibis Neuronav
+Copyright (c) Simon Drouin, Anna Kochanowska, Louis Collins.
+All rights reserved.
+See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+// Thanks to Houssem Gueziri for writing this class
+
+#include "recordtrackingplugininterface.h"
+#include "recordtrackingwidget.h"
+#include "ibisapi.h"
+#include <QtPlugin>
+
+RecordTrackingPluginInterface::RecordTrackingPluginInterface() : m_widget(nullptr)
+{
+}
+
+RecordTrackingPluginInterface::~RecordTrackingPluginInterface()
+{
+}
+
+bool RecordTrackingPluginInterface::CanRun()
+{
+    return true;
+}
+
+QWidget * RecordTrackingPluginInterface::CreateTab()
+{
+    m_widget = new RecordTrackingWidget;
+    m_widget->SetPluginInterface( this );
+
+    IbisAPI *ibisApi = this->GetIbisAPI();
+    connect( ibisApi, SIGNAL( ObjectAdded(int) ), this, SLOT( OnTrackedToolAdded(int) ) );
+    connect( ibisApi, SIGNAL( ObjectRemoved(int) ), this, SLOT( OnTrackedToolRemoved(int) ) );
+
+    return m_widget;
+}
+
+
+bool RecordTrackingPluginInterface::WidgetAboutToClose()
+{
+    IbisAPI *ibisApi = this->GetIbisAPI();
+    disconnect( ibisApi, SIGNAL( ObjectAdded(int) ), this, SLOT( OnTrackedToolAdded(int) ) );
+    disconnect( ibisApi, SIGNAL( ObjectRemoved(int) ), this, SLOT( OnTrackedToolRemoved(int) ) );
+}
+
+void RecordTrackingPluginInterface::OnTrackedToolAdded(int id)
+{
+    if ((id != IbisAPI::InvalidId) && (m_widget))
+    {
+        m_widget->AddTrackedTool(id);
+    }
+}
+
+void RecordTrackingPluginInterface::OnTrackedToolRemoved(int id)
+{
+    if (id != IbisAPI::InvalidId)
+    {
+        if (m_widget)
+        {
+            m_widget->RemoveTrackedTool(id);
+        }
+    }
+}

--- a/IbisPlugins/RecordTracking/recordtrackingplugininterface.h
+++ b/IbisPlugins/RecordTracking/recordtrackingplugininterface.h
@@ -1,0 +1,48 @@
+/*=========================================================================
+Ibis Neuronav
+Copyright (c) Simon Drouin, Anna Kochanowska, Louis Collins.
+All rights reserved.
+See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+// Thanks to Houssem Gueziri for writing this class
+
+#ifndef __RecordTrackingPluginInterface_h_
+#define __RecordTrackingPluginInterface_h_
+
+#include "toolplugininterface.h"
+
+class RecordTrackingWidget;
+
+class RecordTrackingPluginInterface : public ToolPluginInterface
+{
+
+    Q_OBJECT
+    Q_INTERFACES(IbisPlugin)
+    Q_PLUGIN_METADATA(IID "Ibis.RecordTrackingPluginInterface" )
+
+public:
+
+    RecordTrackingPluginInterface();
+    ~RecordTrackingPluginInterface();
+    virtual QString GetPluginName() { return QString("RecordTracking"); }
+    virtual bool WidgetAboutToClose();
+    bool CanRun();
+    QString GetMenuEntryString() { return QString("Record Tracking Information"); }
+
+    QWidget * CreateTab();
+
+protected slots:
+
+    void OnTrackedToolAdded(int);
+    void OnTrackedToolRemoved(int);
+
+private:
+    RecordTrackingWidget * m_widget;
+
+};
+
+#endif

--- a/IbisPlugins/RecordTracking/recordtrackingwidget.cpp
+++ b/IbisPlugins/RecordTracking/recordtrackingwidget.cpp
@@ -1,0 +1,296 @@
+/*=========================================================================
+Ibis Neuronav
+Copyright (c) Simon Drouin, Anna Kochanowska, Louis Collins.
+All rights reserved.
+See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+// Thanks to Houssem Gueziri for writing this class
+
+#include "recordtrackingplugininterface.h"
+#include "recordtrackingwidget.h"
+#include "ui_recordtrackingwidget.h"
+#include "ibisapi.h"
+
+#include <sstream>
+#include <iomanip>
+#include <chrono>
+#include <cstdio>
+#include <unistd.h>
+
+#include <QLabel>
+#include <QCheckBox>
+#include <QSpacerItem>
+#include <QWidgetItem>
+#include <QFileDialog>
+#include <QFile>
+#include <QTime>
+
+RecordTrackingWidget::RecordTrackingWidget(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::RecordTrackingWidget),
+    m_pluginInterface(nullptr),
+    m_recording(false),
+    m_frameId(0),
+    m_cummulativeTime(0),
+    m_recordfile(nullptr)
+{
+    m_temporaryFilename = "";
+    ui->setupUi(this);
+    setWindowTitle( "Rocord Tracking Information" );
+}
+
+RecordTrackingWidget::~RecordTrackingWidget()
+{
+    if (m_recordfile)
+        m_recordfile.close();
+    delete ui;
+}
+
+void RecordTrackingWidget::SetPluginInterface( RecordTrackingPluginInterface * interf )
+{
+    m_pluginInterface = interf;
+    UpdateUi();
+}
+
+void RecordTrackingWidget::on_startButton_clicked()
+{
+    if ((!m_recording) && (m_pluginInterface))
+    {
+        IbisAPI * ibisApi = m_pluginInterface->GetIbisAPI();
+        ui->instrumentGroupBox->setEnabled(false);
+
+        if (m_temporaryFilename != "")
+        {
+            m_recordfile.open(m_temporaryFilename, std::fstream::app);
+            if (m_recordfile)
+            {
+                ui->saveButton->setEnabled(false);
+                ui->startButton->setText(tr("Pause Recording"));
+
+                m_recording = true;
+                m_elapsedTimer.start();
+                connect( ibisApi, SIGNAL(IbisClockTick()), this, SLOT(OnToolsPositionUpdated()) );
+            }
+        }
+        else
+        {
+            m_temporaryFilename = std::tmpnam(nullptr);
+
+            m_recordfile.open(m_temporaryFilename, std::fstream::out);
+            if (m_recordfile)
+            {
+                m_recording = true;
+
+                m_recordedObjectsList.clear();
+                for (int i = 0; i < ui->trackedObjectLayout->count(); ++i)
+                {
+                    QLayoutItem * const item = ui->trackedObjectLayout->itemAt(i);
+                    if(dynamic_cast<QWidgetItem *>(item))
+                    {
+                        QCheckBox *cb = dynamic_cast<QCheckBox *>(item->widget());
+                        if(cb->isChecked())
+                            m_recordedObjectsList.push_back(TrackedSceneObject::SafeDownCast( ibisApi->GetObjectByID(m_trackedObjectIds[i])) );
+                    }
+                }
+
+                ui->saveButton->setEnabled(false);
+                ui->startButton->setText(tr("Pause Recording"));
+                m_frameId = 0;
+
+                m_recordfile << "ObjectType = Image" << std::endl;
+                m_recordfile << "NDims = 3" << std::endl;
+                m_recordfile << "AnatomicalOrientation = RAS" << std::endl;
+                m_recordfile << "BinaryData = True" << std::endl;
+                m_recordfile << "BinaryDataByteOrderMSB = False" << std::endl;
+                m_recordfile << "CenterOfRotation = 0 0 0" << std::endl;
+                m_recordfile << "CompressedData = True" << std::endl;
+                m_recordfile << "CompressedDataSize = 321" << std::endl;
+                m_recordfile << "DimSize = ";
+                m_framenumberfilep = m_recordfile.tellp();
+                m_recordfile << "                         " << std::endl;
+                m_recordfile << "Kinds = domain domain list" << std::endl;
+                m_recordfile << "ElementSpacing = 1 1 1" << std::endl;
+                m_recordfile << "ElementType = MET_UCHAR" << std::endl;
+                m_recordfile << "Offset = 0 0 0" << std::endl;
+                m_recordfile << "TransformMatrix = 1 0 0 0 1 0 0 0 1" << std::endl;
+                m_recordfile << "UltrasoundImageOrientation = UNA" << std::endl;
+
+                m_cummulativeTime = 0;
+                m_elapsedTimer.start();
+                connect( ibisApi, SIGNAL(IbisClockTick()), this, SLOT(OnToolsPositionUpdated()) );
+            }
+        }
+    }
+    else
+    {
+        IbisAPI * ibisApi = m_pluginInterface->GetIbisAPI();
+        disconnect( ibisApi, SIGNAL(IbisClockTick()), this, SLOT(OnToolsPositionUpdated()) );
+        if (m_recordfile)
+        {
+            // write frame number
+            m_recordfile.seekp(m_framenumberfilep);
+            m_recordfile << "1 1 " << m_frameId;
+            m_recordfile.close();
+        }
+
+        m_cummulativeTime += m_elapsedTimer.elapsed();
+        m_recording = false;
+        ui->startButton->setText(tr("Start Recording"));
+        ui->saveButton->setEnabled(true);
+    }
+
+}
+
+
+void RecordTrackingWidget::on_saveButton_clicked()
+{
+    if (m_recording)
+        on_startButton_clicked();
+    IbisAPI *ibisApi = m_pluginInterface->GetIbisAPI();
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Save trackeing sequence"),
+                                                    ibisApi->GetWorkingDirectory(),
+                                                    tr("Tracking sequence (*.mha)"));
+    if (fileName.size() > 0)
+    {
+        if (!fileName.endsWith(".mha"))
+            fileName += ".mha";
+        if (QFile(fileName).exists())
+            std::remove(fileName.toUtf8().constData());
+        if (QFile::copy(tr(m_temporaryFilename.c_str()), fileName))
+        {
+            std::remove(m_temporaryFilename.c_str());
+            m_temporaryFilename = "";
+            ui->saveButton->setEnabled(false);
+            ui->instrumentGroupBox->setEnabled(true);
+        }
+    }
+}
+
+/******************************************************************************************************/
+
+void RecordTrackingWidget::UpdateUi()
+{
+    if (m_pluginInterface)
+    {
+        IbisAPI * ibisApi = m_pluginInterface->GetIbisAPI();
+        ibisApi->GetAllTrackedObjects(m_trackedToolsList);
+
+        m_trackedObjectIds.clear();
+
+        for (int i = 0; i < m_trackedToolsList.size(); ++i)
+        {
+            TrackedSceneObject * obj = TrackedSceneObject::SafeDownCast( m_trackedToolsList.at(i) );
+            QCheckBox *checkbox = new QCheckBox;
+            checkbox->setChecked(true);
+            checkbox->setText( obj->GetName() );
+            checkbox->setProperty("ObjectID", obj->GetObjectID());
+
+            ui->trackedObjectLayout->addWidget(checkbox);
+
+            m_trackedObjectIds.push_back(obj->GetObjectID());
+        }
+    }
+}
+
+void RecordTrackingWidget::AddTrackedTool(int objId)
+{
+    if(m_pluginInterface)
+    {
+        IbisAPI *ibisApi = m_pluginInterface->GetIbisAPI();
+        SceneObject *obj = ibisApi->GetObjectByID(objId);
+        if (obj)
+        {
+            if (obj->IsA("TrackedSceneObject"))
+            {
+                QCheckBox *checkbox = new QCheckBox;
+                checkbox->setChecked(true);
+                checkbox->setText( obj->GetName() );
+                checkbox->setProperty("ObjectID", objId);
+
+                ui->trackedObjectLayout->addWidget(checkbox);
+
+                m_trackedObjectIds.push_back(objId);
+            }
+        }
+    }
+
+}
+
+void RecordTrackingWidget::RemoveTrackedTool(int objId)
+{
+    for(int i = 0; i < ui->trackedObjectLayout->count(); ++i)
+    {
+        QWidget * w = ui->trackedObjectLayout->itemAt(i)->widget();
+        if(w)
+        {
+            if (w->metaObject()->className() == tr("QCheckBox"))
+            {
+                if( objId == w->property("ObjectID").toInt() )
+                {
+                    std::vector<int>::iterator it = std::find(m_trackedObjectIds.begin(), m_trackedObjectIds.end(), objId);
+                    if (it != m_trackedObjectIds.end())
+                        m_trackedObjectIds.erase(it);
+                    ui->trackedObjectLayout->removeWidget(w);
+                    delete w;
+                }
+            }
+        }
+    }
+}
+
+
+void RecordTrackingWidget::OnToolsPositionUpdated()
+{
+
+    if (m_recordfile)
+    {
+        std::stringstream ss;
+        ss << std::setw(10) << std::setfill('0') << m_frameId;
+        std::string strFrameId = ss.str();
+        m_recordfile << "Seq_Frame" + strFrameId + "_FrameNumber = " + strFrameId << std::endl;
+        double timestamp = -1;
+
+        for (size_t i = 0; i < m_recordedObjectsList.size(); ++i)
+        {
+            TrackedSceneObject * obj = m_recordedObjectsList.at(i);
+            std::string msg;
+            std::string toolStatus;
+
+            m_recordfile << "Seq_Frame" + strFrameId + "_" + obj->GetName().toUtf8().constData() + "ToReferenceTransform = "
+                         << this->GetStringFromTransform(obj->GetWorldTransform()) << std::endl;
+            toolStatus = (obj->GetState() == TrackerToolState::Ok) ? "OK" : "INVALID";
+            m_recordfile << "Seq_Frame" + strFrameId + "_" + obj->GetName().toUtf8().constData() + "ToReferenceTransformStatus = "
+                         << toolStatus << std::endl;
+            if (timestamp < 0)
+                timestamp = obj->GetLastTimestamp();
+        }
+
+        m_recordfile << "Seq_Frame" + strFrameId + "_Timestamp = " << std::fixed << timestamp << std::endl;
+        m_recordfile << "Seq_Frame" + strFrameId + "_UnfilteredTimestamp = " << std::fixed << timestamp << std::endl;
+        //m_recordfile << "Seq_Frame" + strFrameId + "_ImageStatus = INVALID" << std::endl;
+        m_frameId++;
+
+        QTime time(0,0,0);
+        time = time.addMSecs(m_elapsedTimer.elapsed() + m_cummulativeTime);
+        ui->numberOfFramesLabel->setText("Number of frames: " + QString::number(m_frameId));
+        ui->elapsedTimeLabel->setText("Time: " + time.toString("hh:mm:ss"));
+    }
+}
+
+std::string RecordTrackingWidget::GetStringFromTransform(vtkTransform * transform)
+{
+    std::stringstream strTransform;
+    for (int i = 0; i < 4; ++i)
+    {
+        for (int j = 0; j < 4; ++j)
+        {
+            double elm = transform->GetMatrix()->GetElement(i,j);
+            strTransform << elm << " ";
+        }
+    }
+    return strTransform.str();
+}

--- a/IbisPlugins/RecordTracking/recordtrackingwidget.h
+++ b/IbisPlugins/RecordTracking/recordtrackingwidget.h
@@ -1,0 +1,78 @@
+/*=========================================================================
+Ibis Neuronav
+Copyright (c) Simon Drouin, Anna Kochanowska, Louis Collins.
+All rights reserved.
+See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+=========================================================================*/
+// Thanks to Houssem Gueziri for writing this class
+
+#ifndef __RecordTrackingWidget_h_
+#define __RecordTrackingWidget_h_
+
+#include <QWidget>
+#include <QElapsedTimer>
+
+#include <fstream>
+#include "trackedsceneobject.h"
+#include <vtkTransform.h>
+#include <vector>
+#include <iostream>
+
+class RecordTrackingPluginInterface;
+
+namespace Ui
+{
+    class RecordTrackingWidget;
+}
+
+
+class RecordTrackingWidget : public QWidget
+{
+
+    Q_OBJECT
+
+public:
+
+    explicit RecordTrackingWidget(QWidget *parent = nullptr);
+    ~RecordTrackingWidget();
+
+    void AddTrackedTool(int);
+    void RemoveTrackedTool(int);
+
+    void SetPluginInterface( RecordTrackingPluginInterface * interf );
+
+private:
+    std::string GetStringFromTransform(vtkTransform *);
+
+private:
+
+    void UpdateUi();
+
+    Ui::RecordTrackingWidget * ui;
+    RecordTrackingPluginInterface * m_pluginInterface;
+
+    bool m_recording;
+    std::ofstream m_recordfile;
+    QList<TrackedSceneObject *> m_trackedToolsList;
+    unsigned long int m_frameId;
+    std::vector<int> m_trackedObjectIds;
+    std::vector<TrackedSceneObject *> m_recordedObjectsList;
+    std::iostream::pos_type m_framenumberfilep;
+    std::string m_temporaryFilename;
+    QElapsedTimer m_elapsedTimer;
+    qint64 m_cummulativeTime;
+
+
+private slots:
+
+    void on_startButton_clicked();
+    void on_saveButton_clicked();
+    void OnToolsPositionUpdated();
+
+};
+
+#endif

--- a/IbisPlugins/RecordTracking/recordtrackingwidget.ui
+++ b/IbisPlugins/RecordTracking/recordtrackingwidget.ui
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RecordTrackingWidget</class>
+ <widget class="QWidget" name="RecordTrackingWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>474</width>
+    <height>196</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignLeft|Qt::AlignTop">
+    <widget class="QGroupBox" name="instrumentGroupBox">
+     <property name="title">
+      <string>Tracked Instrument(s):</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QVBoxLayout" name="trackedObjectLayout"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="startButton">
+       <property name="text">
+        <string>Start</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Save...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QLabel" name="numberOfFramesLabel">
+       <property name="text">
+        <string>Number of frames: -</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="elapsedTimeLabel">
+       <property name="text">
+        <string>Time: -</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Plugin to record tracked tools using MetaIO format ([see description](http://perk-software.cs.queensu.ca/plus/doc/nightly/user/FileSequenceFile.html)). Tracked information are exported in .mha file that can be read using Sequencer on 3D Slicer, for example.
In a long term it would be interesting to have it as a SceneObject (SequenceObject).

Tested on Linux and Windows, with Atracsys and Polaris tracking configurations. Can someone perform further testing (on Mac?).
It works with the legacy Hardware module, but it is not recommended due to timestamp behaviour.