### PR TITLE
Add access to dock features through API

### DIFF
--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -320,9 +320,9 @@ void Application::RemoveBottomWidget( QWidget * w )
     m_mainWindow->RemoveBottomWidget( w );
 }
 
-void Application::ShowFloatingDock( QWidget * w )
+void Application::ShowFloatingDock( QWidget * w, QFlags<QDockWidget::DockWidgetFeature> features )
 {
-    m_mainWindow->ShowFloatingDock( w );
+    m_mainWindow->ShowFloatingDock( w, features );
 }
 
 void Application::OnStartMainLoop()

--- a/IbisLib/application.h
+++ b/IbisLib/application.h
@@ -15,6 +15,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QSize>
 #include <QPoint>
 #include <QColor>
+#include <QDockWidget>
 #include "serializer.h"
 #include <vector>
 #include "ibistypes.h"
@@ -47,6 +48,7 @@ class ImageObject;
 class PointsObject;
 class QMenu;
 class IbisPreferences;
+class QDockWidget;
 
 struct ApplicationSettings
 {
@@ -97,7 +99,7 @@ public:
     void AddBottomWidget( QWidget * w );
     void RemoveBottomWidget( QWidget * w );
 
-    void ShowFloatingDock( QWidget * w );
+    void ShowFloatingDock( QWidget * w, QFlags<QDockWidget::DockWidgetFeature> features=QDockWidget::AllDockWidgetFeatures );
 
     void OnStartMainLoop();
     void AddGlobalEventHandler( GlobalEventHandler * h );

--- a/IbisLib/application.h
+++ b/IbisLib/application.h
@@ -48,7 +48,6 @@ class ImageObject;
 class PointsObject;
 class QMenu;
 class IbisPreferences;
-class QDockWidget;
 
 struct ApplicationSettings
 {

--- a/IbisLib/ibisapi.cpp
+++ b/IbisLib/ibisapi.cpp
@@ -447,9 +447,9 @@ void IbisAPI::RemoveBottomWidget( QWidget * w )
     m_application->RemoveBottomWidget( w );
 }
 
-void IbisAPI::ShowFloatingDock( QWidget * w )
+void IbisAPI::ShowFloatingDock( QWidget * w, QFlags<QDockWidget::DockWidgetFeature> features )
 {
-    m_application->ShowFloatingDock( w );
+    m_application->ShowFloatingDock( w, features );
 }
 
 IbisPreferences * IbisAPI::GetIbisPreferences()

--- a/IbisLib/ibisapi.h
+++ b/IbisLib/ibisapi.h
@@ -14,6 +14,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QObject>
 #include <QList>
 #include <QMap>
+#include <QDockWidget>
 
 class Application;
 class SceneManager;
@@ -37,6 +38,7 @@ class vtkMatrix4x4;
 
 class QProgressDialog;
 class QString;
+class QDockWidget;
 
 class OpenFileParams
 {
@@ -348,7 +350,7 @@ public:
     void SetRightPanelVisibility( bool v );
     void AddBottomWidget( QWidget * w );
     void RemoveBottomWidget( QWidget * w );
-    void ShowFloatingDock( QWidget * w );
+    void ShowFloatingDock( QWidget * w, QFlags<QDockWidget::DockWidgetFeature> features=QDockWidget::AllDockWidgetFeatures );
     /** @}*/
     /**
      * @{

--- a/IbisLib/ibisapi.h
+++ b/IbisLib/ibisapi.h
@@ -38,7 +38,6 @@ class vtkMatrix4x4;
 
 class QProgressDialog;
 class QString;
-class QDockWidget;
 
 class OpenFileParams
 {

--- a/IbisLib/mainwindow.cpp
+++ b/IbisLib/mainwindow.cpp
@@ -34,7 +34,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QMessageBox>
 #include <QProgressDialog>
 #include <QSplitter>
-#include <QDockWidget>
 #include <QDir>
 #include <QLayout>
 #include <QFileInfo>
@@ -878,12 +877,13 @@ void MainWindow::RemoveBottomWidget( QWidget * w )
     m_4Views->RemoveBottomWidget( w );
 }
 
-void MainWindow::ShowFloatingDock( QWidget * w )
+void MainWindow::ShowFloatingDock( QWidget * w, QFlags<QDockWidget::DockWidgetFeature> features )
 {
     QDockWidget * dock = new QDockWidget( this );
     dock->setWindowTitle( w->windowTitle() );
     dock->resize( w->size() );
     dock->setAttribute( Qt::WA_DeleteOnClose );
+    dock->setFeatures( features );
     dock->setAllowedAreas( Qt::NoDockWidgetArea );
     dock->setFloating( true );
     dock->move(this->pos().x() + this->size().width()/2 - dock->size().width()/2,

--- a/IbisLib/mainwindow.h
+++ b/IbisLib/mainwindow.h
@@ -13,6 +13,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 #include <QMainWindow>
 #include <QMap>
+#include <QDockWidget>
 #include "serializer.h"
 
 class QAction;
@@ -29,6 +30,7 @@ class ImageMixerWidget;
 class OpenFileParams;
 class ToolPluginInterface;
 class QuadViewWindow;
+class QDockWidget;
 
 class MainWindow : public QMainWindow
 {
@@ -42,7 +44,7 @@ public:
     virtual void Serialize( Serializer * ser );
     void AddBottomWidget( QWidget * w );
     void RemoveBottomWidget( QWidget * w );
-    void ShowFloatingDock( QWidget * w );
+    void ShowFloatingDock( QWidget * w, QFlags<QDockWidget::DockWidgetFeature> features=QDockWidget::AllDockWidgetFeatures );
     void SetShowToolbar( bool show );
     void SetShowLeftPanel( bool show );
     void SetShowRightPanel( bool show );

--- a/IbisLib/mainwindow.h
+++ b/IbisLib/mainwindow.h
@@ -30,7 +30,6 @@ class ImageMixerWidget;
 class OpenFileParams;
 class ToolPluginInterface;
 class QuadViewWindow;
-class QDockWidget;
 
 class MainWindow : public QMainWindow
 {


### PR DESCRIPTION
Add access to QDockWidget::DockWidgetFeature flags with IbisAPI::ShowFloatingDock().
DockWidgetFeature allows to control movability, floatability of the dock widget. It also allows to enable/disable the close widget button on top corner. The default value is AllDockWidgetFeatures which should not modify the actual behaviour of the dock when no feature flag is specified.

Closing dock widget with the close button produces some unexpected behaviour in Linux (the widget minimizes but stays visible). It might be useful to have lower-level access to the dock widget (maybe to Attribute of the dock widget as well?).