### PR TITLE
Disable removal of ImagePlanes

### DIFF
--- a/IbisLib/gui/objecttreewidget.cpp
+++ b/IbisLib/gui/objecttreewidget.cpp
@@ -178,7 +178,7 @@ void ObjectTreeWidget::UpdateObjectSettingsWidget()
         ui->addTransformAllChildrenButton->setEnabled( object->GetNumberOfChildren() != 0 && canTransformAllChildren );
 
         SceneObject * parent = object->GetParent();
-        ui->addParentTransformButton->setEnabled( parent && parent->CanAppendChildren() );
+        ui->addParentTransformButton->setEnabled( parent && parent->CanAppendChildren() && object->CanChangeParent() );
     }
     else
     {


### PR DESCRIPTION
Adding parent transform to objects that cannot change parents is disabled. This prevents removal of the ImagePlanes.