### PR TITLE
Fixed OpenFileDialog for Qt5.12 and higher

### DIFF
--- a/IbisLib/gui/opendatafiledialog.cpp
+++ b/IbisLib/gui/opendatafiledialog.cpp
@@ -34,7 +34,7 @@ OpenDataFileDialog::~OpenDataFileDialog()
 void OpenDataFileDialog::BrowsePushButtonClicked()
 {
     QString filter = tr("All valid files(*.mnc *.mnc2 *.mnc.gz *.MNC *.MNC2 *.MNC.GZ *.nii *.obj *.ply *.tag *.vtk *.vtp);;Minc file (*.mnc *.mnc2 *.mnc.gz *.MNC *.MNC2 *.MNC.GZ);;Nifti file (*.nii);;Object file (*.obj);;PLY file (*.ply);;Tag file (*.tag);;VTK file (*.vtk);;VTP file (*.vtp)");
-    QStringList inputFiles = QFileDialog::getOpenFileNames( this, tr("Open Files"), m_fileParams->lastVisitedDir, filter );
+    QStringList inputFiles = QFileDialog::getOpenFileNames( this, tr("Open Files"), m_fileParams->lastVisitedDir, filter, nullptr, QFileDialog::DontUseNativeDialog );
     for( int i = 0; i < inputFiles.size(); ++i )
     {
         OpenFileParams::SingleFileParam param;


### PR DESCRIPTION
Not tested on Windows or MAC. On Ubuntu tested with  Qt5.9.8, Qt 5.12.9, and Qt 5.15.0.
Only OpenFileDialog opens multiple files in ibis, so only one change was required.