### PR TITLE
Possible fix for cleaning bug #358

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,3 +191,7 @@ if( IBIS_BUILD_DOCUMENTATION )
         message("Doxygen needs to be installed to generate documentation")
     endif (DOXYGEN_FOUND)
 endif()
+
+#cleaning
+set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_CURRENT_BINARY_DIR}/version.h)
+set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${GIT_STATE_FILE})


### PR DESCRIPTION
Remove files git-state and version.h during make clean operation.
I added removal in ibis/CMakeLists.txt as I do not know how to do it in gitwatcher.cmake.
Simon, you might know.
