### PR TITLE
Don't force compiling with c++11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,6 @@ PROJECT( ibis )
 
 INCLUDE(CMakeDependentOption)
 
-#----------------------------------------
-# Tell the compiler to use c++11 which is required with Qt >= 5.7
-set( CMAKE_CXX_STANDARD 11 )
-#----------------------------------------
-
 #==================================================================
 # Define a variable to hold the path of automatically compiled
 # dependencies.


### PR DESCRIPTION
New systems are already at c++ 17 or higher. When we force using c++ 11, we get zillions of warnings that we compile ibis with compiler older than the one to use for the libraries in SuperBuild.