### PR TITLE
Do not build python support for opencv

### DIFF
--- a/IbisSuperBuild/IbisDeps/External_OpenCV.cmake
+++ b/IbisSuperBuild/IbisDeps/External_OpenCV.cmake
@@ -22,4 +22,4 @@ ExternalProject_Add( ${opencv_name}
                -DWITH_CUDA:BOOL=FALSE
                -DWITH_VTK:BOOL=FALSE
                -DBUILD_opencv_python2:BOOL=FALSE
-               -DBUILD_opencv_python2:BOOL=FALSE )
+               -DBUILD_opencv_python3:BOOL=FALSE )

--- a/IbisSuperBuild/IbisDeps/External_OpenCV.cmake
+++ b/IbisSuperBuild/IbisDeps/External_OpenCV.cmake
@@ -20,4 +20,6 @@ ExternalProject_Add( ${opencv_name}
                -DBUILD_DOCS:BOOL=FALSE
                -DBUILD_FAT_JAVA_LIB:BOOL=FALSE
                -DWITH_CUDA:BOOL=FALSE
-               -DWITH_VTK:BOOL=FALSE )
+               -DWITH_VTK:BOOL=FALSE
+               -DBUILD_opencv_python2:BOOL=FALSE
+               -DBUILD_opencv_python2:BOOL=FALSE )


### PR DESCRIPTION
Newer compilers are picky on this version and do not compile. Need to upgrade version of OpenCV in the near future. Current is 4.5, ours is 3.2