### PR TITLE
Fix USACquisition double view

### DIFF
--- a/IbisPlugins/USAcquisition/doubleviewwidget.h
+++ b/IbisPlugins/USAcquisition/doubleviewwidget.h
@@ -30,6 +30,7 @@ class vtkImageActor;
 class vtkAlgorithmOutput;
 class vtkTransform;
 class vtkImageStack;
+class vtkImageSlice;
 
 class DoubleViewWidget : public QWidget
 {
@@ -85,7 +86,7 @@ private:
     vtkSmartPointer<vtkImageStack> m_mriActor;
     vtkSmartPointer<vtkImageActor> m_vol1Slice;
     vtkSmartPointer<vtkImageActor> m_vol2Slice;
-    vtkSmartPointer<vtkImageActor> m_usSlice;
+    vtkSmartPointer<vtkImageSlice> m_usSlice;
     vtkSmartPointer<vtkRenderer> m_mriRenderer;
     vtkSmartPointer<vtkRenderer> m_usRenderer;
     vtkSmartPointer<vtkImageActor> m_usActor;


### PR DESCRIPTION
- vtkRenderWidget->update() does not seem to work properly (does not update rendering), instead use vtkRenderWidget->renderWindow()->Render() to force render update
- add SetOutputFormatToRGB  to force vtkImageResliceToColors output format
- when using vtkImageStack, vtkImageActor has some issues rescaling colours of the lookup table resulting in an incorrect display of the US image on the right window. This issue seems to exist since Oct 19 (see [here](https://discourse.vtk.org/t/cannot-control-opacity-of-vtkimageactors/1943/8)). A workaround is to use vtkImageSlice instead.