### PR TITLE
Add shallow depth calibration

### DIFF
--- a/IbisPlugins/USManualCalibration/usmanualcalibrationplugininterface.h
+++ b/IbisPlugins/USManualCalibration/usmanualcalibrationplugininterface.h
@@ -28,6 +28,8 @@ class USManualCalibrationPluginInterface : public ToolPluginInterface
 
 public:
 
+    enum PhantomSize { MEDIUMDEPTH = 0, SHALLOWDEPTH = 1 };
+
     USManualCalibrationPluginInterface();
     ~USManualCalibrationPluginInterface();
     virtual QString GetPluginName() override { return QString("USManualCalibration"); }
@@ -45,16 +47,21 @@ public:
     const double * GetPhantomPoint( int nIndex, int pointIndex );
     SceneObject * GetCalibrationPhantomObject();
 
+    void SetPhatonSize(int);
+
 protected:
 
     void ValidateUsProbe();
     void BuildCalibrationPhantomRepresentation();
+    void UpdateCalibrationPhantomRepresentation();
 
     int m_calibrationPhantomObjectId;
     int m_phantomRegSourcePointsId;
     int m_phantomRegTargetPointsId;
     int m_landmarkRegistrationObjectId;
     int m_usProbeObjectId;
+
+    PhantomSize m_currentPhantomSize;
 };
 
 #endif

--- a/IbisPlugins/USManualCalibration/usmanualcalibrationwidget.cpp
+++ b/IbisPlugins/USManualCalibration/usmanualcalibrationwidget.cpp
@@ -136,6 +136,7 @@ void USManualCalibrationWidget::UpdateUi()
     //calibResults += QString("Reprojection error: %1\n").arg( calib->GetReprojectionError() );
     //ui->calibrationResultTextEdit->setPlainText( calibResults );
     ui->resetButton->setEnabled( m_imageFrozen );
+    ui->depthComboBox->setEnabled( !m_imageFrozen );
 }
 
 void USManualCalibrationWidget::EnableManipulators( bool on )
@@ -425,4 +426,12 @@ void USManualCalibrationWidget::on_resetButton_clicked()
     m_manipulators[ 3 ]->SetMiddlePoint( 0.5 );
 
     OnManipulatorsModified();
+}
+
+void USManualCalibrationWidget::on_depthComboBox_currentIndexChanged(int index)
+{
+    if( m_pluginInterface )
+    {
+        m_pluginInterface->SetPhatonSize(index);
+    }
 }

--- a/IbisPlugins/USManualCalibration/usmanualcalibrationwidget.h
+++ b/IbisPlugins/USManualCalibration/usmanualcalibrationwidget.h
@@ -53,6 +53,7 @@ private slots:
     void OnManipulatorsModified();
     void on_freezeVideoButton_toggled(bool checked);
     void on_resetButton_clicked();
+    void on_depthComboBox_currentIndexChanged(int);
 
 private:
 

--- a/IbisPlugins/USManualCalibration/usmanualcalibrationwidget.ui
+++ b/IbisPlugins/USManualCalibration/usmanualcalibrationwidget.ui
@@ -106,6 +106,37 @@
       </layout>
      </item>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Phantom size</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="depthComboBox">
+         <item>
+          <property name="text">
+           <string>Medium - probe depth (7 cm - 14 cm)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Shallow - probe depth (3 cm - 7 cm)</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
       <widget class="QTextEdit" name="calibrationResultTextEdit"/>
      </item>
     </layout>


### PR DESCRIPTION
I added the dimensions for US calibration of probes with a smaller depth (>2 cm - ~7 cm). The string configurations (i.e., string coordinates) can be selected from the plugin, but needs to be consistent with the physical model.

- Calibration needs to be tested.
- The 3D model of the phantom needs to be updated to allow string placement for the new configuration.
- It would be nice to have the polydata of the 3D model displayed in the 3D view.