### PR TITLE
Plugin Animate - replacing call to non-existing GetQtRenderWidget()

### DIFF
--- a/IbisPlugins/Animate/CameraAnimation.h
+++ b/IbisPlugins/Animate/CameraAnimation.h
@@ -27,7 +27,7 @@ class CameraAnimation : public Animation< CameraKey >
 public:
 	
 	CameraAnimation();
-	~CameraAnimation();
+    virtual ~CameraAnimation();
 	
 	void AddKeyframe( int frame, vtkCamera * cam );
     virtual void MoveKey( int oldFrame, int newFrame );

--- a/IbisPlugins/Animate/animateplugininterface.h
+++ b/IbisPlugins/Animate/animateplugininterface.h
@@ -32,6 +32,7 @@ class QTime;
 class DomeRenderState : public vtkIbisRenderState
 {
 public:
+    virtual ~DomeRenderState() {}
     virtual void GetRenderSize( vtkRenderer * ren, int size[2] );
 };
 

--- a/IbisPlugins/Animate/doublevalueanimation.h
+++ b/IbisPlugins/Animate/doublevalueanimation.h
@@ -48,6 +48,7 @@ class DoubleValueAnimation : public Animation<DoubleValueKey>
 public:
 
     DoubleValueAnimation();
+    virtual ~DoubleValueAnimation() {}
 
     void Serialize( Serializer * ser );
 };

--- a/IbisPlugins/Animate/offscreenrenderer.cpp
+++ b/IbisPlugins/Animate/offscreenrenderer.cpp
@@ -103,7 +103,8 @@ void OffscreenRenderer::Setup()
     //-------------------------------
     // Make GL context current
     //-------------------------------
-    vtkOpenGLRenderWindow * win = vtkOpenGLRenderWindow::SafeDownCast( m_animate->GetIbisAPI()->GetMain3DView()->GetQtRenderWidget()->GetRenderWindow() );
+    vtkRenderer *ren = m_animate->GetIbisAPI()->GetMain3DView()->GetRenderer();
+    vtkOpenGLRenderWindow * win = vtkOpenGLRenderWindow::SafeDownCast( ren->GetRenderWindow() );
     Q_ASSERT( win );
     win->SetForceMakeCurrent();
     win->MakeCurrent();
@@ -151,7 +152,6 @@ void OffscreenRenderer::Setup()
     //-------------------------------
     m_cam = vtkOffscreenCamera::New();
     m_cam->SetRenderSize( m_renderSize );
-    vtkRenderer * ren = m_animate->GetIbisAPI()->GetMain3DView()->GetRenderer();
     m_backupCam = ren->GetActiveCamera();
     m_cam->DeepCopy( m_backupCam );
     ren->SetActiveCamera( m_cam );

--- a/IbisPlugins/Animate/transferfunctionkey.h
+++ b/IbisPlugins/Animate/transferfunctionkey.h
@@ -54,6 +54,7 @@ class TFAnimation : public Animation<TransferFunctionKey>
 
 public:
 
+    virtual ~TFAnimation() {}
     void Serialize( Serializer * ser );
 };
 


### PR DESCRIPTION
Animate did not compile because class view does not have a function GetQtRenderWidget(). I changed the code the same way as in DomeRenderer.cpp. Maybe it would be better to implement GetQtRenderWidget()? It would complement SetQtRenderWidget()