### PR TITLE
Patch removal

### DIFF
--- a/IbisLib/gui/transformeditwidget.cpp
+++ b/IbisLib/gui/transformeditwidget.cpp
@@ -209,7 +209,6 @@ void TransformEditWidget::SetIdentityButtonClicked()
         if( transform )
         {
             transform->Identity();
-            transform->Modified(); // this patch is added to correct vtk bug in vtkTransform::Identity() and will be removed once vtk is fixed.
             this->UpdateUi();
         }
     }


### PR DESCRIPTION
We do not need to call Modified() after call to vtkTransform::Identitty(), this function was corrected in vtk 8.2 and later.