### PR TITLE
FrameRateTester adapted to vtk 9

### DIFF
--- a/IbisPlugins/FrameRateTester/frameratetesterplugininterface.cpp
+++ b/IbisPlugins/FrameRateTester/frameratetesterplugininterface.cpp
@@ -113,8 +113,7 @@ void FrameRateTesterPluginInterface::OnTimerTriggered()
         m_time->restart();
 
     // Render
-    View *v = GetIbisAPI()->GetViewByID( m_currentViewID );
-    v->GetRenderer()->Render();
+    GetIbisAPI()->GetViewByID( m_currentViewID )->NotifyNeedRender();
 
     // Increment stats
     m_lastPeriod = ((double)m_time->elapsed()) * 0.001;

--- a/IbisPlugins/FrameRateTester/frameratetesterplugininterface.cpp
+++ b/IbisPlugins/FrameRateTester/frameratetesterplugininterface.cpp
@@ -17,6 +17,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QTimer>
 #include <QTime>
 #include <QMap>
+#include <vtkRenderer.h>
 
 FrameRateTesterPluginInterface::FrameRateTesterPluginInterface()
 {
@@ -112,8 +113,8 @@ void FrameRateTesterPluginInterface::OnTimerTriggered()
         m_time->restart();
 
     // Render
-//    GetIbisAPI()->GetViewByID( m_currentViewID )->Render();
-    GetIbisAPI()->GetViewByID( m_currentViewID )->NotifyNeedRender();
+    View *v = GetIbisAPI()->GetViewByID( m_currentViewID );
+    v->GetRenderer()->Render();
 
     // Increment stats
     m_lastPeriod = ((double)m_time->elapsed()) * 0.001;

--- a/IbisPlugins/FrameRateTester/frameratetesterplugininterface.cpp
+++ b/IbisPlugins/FrameRateTester/frameratetesterplugininterface.cpp
@@ -112,7 +112,8 @@ void FrameRateTesterPluginInterface::OnTimerTriggered()
         m_time->restart();
 
     // Render
-    GetIbisAPI()->GetViewByID( m_currentViewID )->Render();
+//    GetIbisAPI()->GetViewByID( m_currentViewID )->Render();
+    GetIbisAPI()->GetViewByID( m_currentViewID )->NotifyNeedRender();
 
     // Increment stats
     m_lastPeriod = ((double)m_time->elapsed()) * 0.001;

--- a/IbisPlugins/FrameRateTester/frameratetesterwidget.cpp
+++ b/IbisPlugins/FrameRateTester/frameratetesterwidget.cpp
@@ -14,7 +14,9 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "ui_frameratetesterwidget.h"
 #include "frameratetesterplugininterface.h"
 #include "ibisapi.h"
-#include "vtkqtrenderwindow.h"
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
+#include <QVTKRenderWidget.h>
 #include <QSize>
 #include <QMap>
 #include <QComboBox>
@@ -57,7 +59,12 @@ void FrameRateTesterWidget::UpdateUi()
 
     // View size
     View * v = m_pluginInterface->GetIbisAPI()->GetViewByID( m_pluginInterface->GetCurrentViewID() );
-    QSize s = v->GetQtRenderWindow()->size();
+    vtkRenderer *ren = v->GetRenderer();
+    vtkRenderWindow * win = vtkRenderWindow::SafeDownCast( ren->GetRenderWindow() );
+    QSize s;
+    s.setWidth( win->GetSize()[0] );
+
+    s.setHeight( win->GetSize()[1] );
     ui->windowSizeLabel->setText( QString("Size : %1 x %2").arg( s.width() ).arg( s.height() ) );
 
     // Run button


### PR DESCRIPTION
I'm not sure how to replace code  in FrameRateTesterPluginInterface::OnTimerTriggered()

Old code:
    GetIbisAPI()->GetViewByID( m_currentViewID )->Render();

I replaced with:
    GetIbisAPI()->GetViewByID( m_currentViewID )->NotifyNeedRender(); 

But, maybe it should be like this:

View *v = GetIbisAPI()->GetViewByID( m_currentViewID );
    v->GetRenderer()->Render();

Is anyone using this plugin?
The window size is not refreshed in the plugin GUI when currently selected window is resized. It never was. I'll fix it, but first let me know which code for rendering is correct.
