### PR TITLE
Tool plugins UI created after settng MainWindow in the Application

### DIFF
--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -143,6 +143,8 @@ Application::Application( )
 void Application::SetMainWindow( MainWindow * mw )
 {
     m_mainWindow = mw;
+    // Create UI elements from the plugins
+    m_mainWindow->CreatePluginsUi();
 }
 
 void Application::LoadWindowSettings()

--- a/IbisLib/mainwindow.cpp
+++ b/IbisLib/mainwindow.cpp
@@ -209,11 +209,6 @@ MainWindow::MainWindow( QWidget * parent )
 
     UpdateMainSplitter();
 
-    // -----------------------------------------
-    // Create UI elements from the plugins
-    // -----------------------------------------
-    CreatePluginsUi();
-
     // Tell the qApp unique instance to send event to MainWindow::eventFilter before anyone else
     // so that we can grab global keyboard shortcuts.
     qApp->installEventFilter(this);

--- a/IbisLib/mainwindow.h
+++ b/IbisLib/mainwindow.h
@@ -52,6 +52,8 @@ public:
     void LoadSettings( QSettings & s );
     void SaveSettings( QSettings & s );
 
+    void CreatePluginsUi();
+
 public slots:
 
     void OnStartMainLoop();
@@ -99,7 +101,6 @@ private slots:
 protected:
 
     void OpenFiles( OpenFileParams * params );
-    void CreatePluginsUi();
     void CreateNewObjectPluginsUi(QMenu *);
     QAction * AddToggleAction( QMenu * menu, const QString & title, const char * member, const QKeySequence & shortcut, bool checked );
     void closeEvent( QCloseEvent * event );


### PR DESCRIPTION
Fixing issue #390 - crash on start when any tool plugin was saved as active.