### PR TITLE
Use fixed size to display cursor coordinates

### DIFF
--- a/IbisLib/gui/quadviewwindow.cpp
+++ b/IbisLib/gui/quadviewwindow.cpp
@@ -355,7 +355,8 @@ void QuadViewWindow::OnCursorMoved()
 {
     double cursorPos[3];
     m_sceneManager->GetCursorPosition( cursorPos );
-    QString text = QString( "Cursor: ( %1, %2, %3 )" ).arg( cursorPos[0] ).arg( cursorPos[1] ).arg( cursorPos[2] );
+    QString text;
+    text.sprintf("Cursor: ( %.2f, %.2f, %.2f )\t", cursorPos[0], cursorPos[1], cursorPos[2]);
     m_cursorPosLabel->setText( text );
 }
 


### PR DESCRIPTION
Issue: when ibis is on small window, the number of digits for cursor coordinates stretches the mainview.
Fix: use a fixed size of floating number + a tab \t buffer format to display coordinates.