### PR TITLE
rotate camera around reference object center.

### DIFF
--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -484,9 +484,6 @@ void Application::OpenFiles( OpenFileParams * params, bool addToScene )
         }
     }
 
-    // See if it is the first batch of objects loaded/created
-    int initialNumberOfUserObjects = GetSceneManager()->GetNumberOfUserObjects();
-
     m_fileReader->start();
 
     // Create a progress dialog and a timer to update it
@@ -546,6 +543,8 @@ void Application::OpenFiles( OpenFileParams * params, bool addToScene )
                     Application::GetSceneManager()->SetCurrentObject( cur.loadedObject );
                 }
             }
+            // See if it is the first batch of objects loaded/created
+            int initialNumberOfUserObjects = GetSceneManager()->GetNumberOfUserObjects();
 
             if( initialNumberOfUserObjects == 0 )
             {

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -702,9 +702,6 @@ void SceneManager::AddObjectUsingID( SceneObject * object, SceneObject * attachT
     // Attach object to the hierarchy
     attachTo->AddChild( object );
 
-    if( !GetReferenceDataObject() && CanBeReference( object ) )
-        SetReferenceDataObject( object );
-
     // Setup in views
     this->SetupInAllViews( object );
     object->PreDisplaySetup();
@@ -713,6 +710,9 @@ void SceneManager::AddObjectUsingID( SceneObject * object, SceneObject * attachT
     // at this point the object is already added to the list
     if( this->GetNumberOfUserObjects() == 1 && object->IsUserObject() )
         this->ResetAllCameras();
+
+    if( !GetReferenceDataObject() && CanBeReference( object ) )
+        SetReferenceDataObject( object );
 
     // Notify clients the object has been added
     if( object->IsListable() )

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -537,6 +537,12 @@ void View::ReferenceTransformChanged()
 
             cam->ApplyTransform( t );
 
+            double center[3];
+            double newFocal[3];
+            obj->GetCenter( center );
+            refTransform->TransformPoint( center, newFocal );
+            cam->SetFocalPoint( newFocal );
+
             // backup inverted current transform
             this->PrevViewingTransform->DeepCopy( refTransform->GetMatrix() );
             this->PrevViewingTransform->Invert();

--- a/IbisLib/view.cpp
+++ b/IbisLib/view.cpp
@@ -537,12 +537,8 @@ void View::ReferenceTransformChanged()
 
             cam->ApplyTransform( t );
 
-            double center[3];
-            double newFocal[3];
-            obj->GetCenter( center );
-            refTransform->TransformPoint( center, newFocal );
-            cam->SetFocalPoint( newFocal );
-
+            if ( this->Manager->Is3DViewFollowingReferenceVolume() )
+                this->SetRotationCenter3D();
             // backup inverted current transform
             this->PrevViewingTransform->DeepCopy( refTransform->GetMatrix() );
             this->PrevViewingTransform->Invert();
@@ -602,7 +598,10 @@ void View::AdjustCameraDistance( double viewAngle )
     double wantedAngle = vtkMath::RadiansFromDegrees( viewAngle * 0.5 );
     double du = dr * tan( vtkHardcodedAngle ) / tan( wantedAngle );
     Vec3 newPos = pos + ( dr - du ) * ndir;
-    cam->SetPosition( newPos.Ref() );
+    if ( this->Manager->Is3DViewFollowingReferenceVolume() )
+        this->SetRotationCenter3D();
+    else
+        cam->SetPosition( newPos.Ref() );
     cam->SetViewAngle( viewAngle );
 }
 
@@ -650,5 +649,34 @@ void View::Reset2DView()
         vtkMatrix4x4Operators::MultiplyVector( transform->GetMatrix(), up.Ref(), newVup.Ref() );
         cam->SetPosition( newPos.Ref() );
         cam->SetViewUp( newVup.Ref() );
+    }
+}
+
+void View::SetRotationCenter3D()
+{
+    ImageObject * obj = this->Manager->GetReferenceDataObject();
+
+    if ( obj )
+    {
+        vtkCamera * cam = this->Renderer->GetActiveCamera();
+        vtkTransform * refTransform = obj->GetWorldTransform();
+
+        double center[3];
+        double focal[3];
+        double newFocal[3];
+        double pos[3];
+        double newPos[3];
+        cam->GetPosition( pos );
+        cam->GetFocalPoint( focal );
+        obj->GetCenter( center );
+        refTransform->TransformPoint( center, newFocal );
+        for( int i = 0; i < 3; i++ )
+        {
+            newPos[i] = pos[i] + newFocal[i] - focal[i];
+        }
+
+        cam->SetFocalPoint( newFocal );
+        cam->SetPosition( newPos );
+        cam->OrthogonalizeViewUp();
     }
 }

--- a/IbisLib/view.h
+++ b/IbisLib/view.h
@@ -143,6 +143,7 @@ protected:
     void GetPositionAndModifier( int & x, int & y, unsigned & modifier );
     void AdjustCameraDistance( double viewAngle );
     void Reset2DView();
+    void SetRotationCenter3D();
 
     QString Name;
     vtkQtRenderWindow * RenderWindow;


### PR DESCRIPTION
Tested on 2 different object loaded simultaneously, and checked if changing reference works properly. 