### PR TITLE
Transform issue #296

### DIFF
--- a/IbisLib/gui/transformeditwidget.cpp
+++ b/IbisLib/gui/transformeditwidget.cpp
@@ -24,7 +24,8 @@ TransformEditWidget::TransformEditWidget(QWidget *parent) :
     m_sceneObject(nullptr),
     m_selfUpdating(false),
     m_matrixDialog(nullptr),
-    m_worldMatrixDialog(nullptr)
+    m_worldMatrixDialog(nullptr),
+    m_mustUpdateTransform(false)
 {
     ui->setupUi(this);
     m_transformModifiedConnection = vtkEventQtSlotConnect::New();
@@ -131,6 +132,11 @@ void TransformEditWidget::UpdateUi()
             ui->rotateXSpinBox->setValue( r[0] );
             ui->rotateYSpinBox->setValue( r[1] );
             ui->rotateZSpinBox->setValue( r[2] );
+            if( m_mustUpdateTransform )
+            {
+                this->UpdateTransform();
+                m_mustUpdateTransform = false;
+            }
         }
         BlockSpinboxSignals(false);
     }
@@ -165,9 +171,10 @@ void TransformEditWidget::EditMatrixButtonToggled( bool isOn )
             m_matrixDialog->setAttribute( Qt::WA_DeleteOnClose );
             m_matrixDialog->SetMatrix( t->GetMatrix() );
             Application::GetInstance().ShowFloatingDock( m_matrixDialog );
-            connect( m_matrixDialog, SIGNAL(MatrixModified()), m_sceneObject, SLOT(NotifyTransformChanged()) );
+//            connect( m_matrixDialog, SIGNAL(MatrixModified()), m_sceneObject, SLOT(NotifyTransformChanged()) );
             connect( m_matrixDialog, SIGNAL(MatrixModified()), this, SLOT(UpdateUi()) );
             connect( m_matrixDialog, SIGNAL(destroyed()), this, SLOT(EditMatrixDialogClosed()) );
+            m_mustUpdateTransform = true;
         }
     }
 }

--- a/IbisLib/gui/transformeditwidget.h
+++ b/IbisLib/gui/transformeditwidget.h
@@ -16,6 +16,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 class vtkEventQtSlotConnect;
 class vtkQtMatrixDialog;
+class vtkMatrix4x4;
 class SceneObject;
 
 namespace Ui {
@@ -47,14 +48,14 @@ private:
     bool m_selfUpdating;
     vtkQtMatrixDialog * m_matrixDialog;
     vtkQtMatrixDialog * m_worldMatrixDialog;
-    bool m_mustUpdateTransform;
 
 public slots:
     void UpdateUi();         // take data in transform and put it in ui
 
 private slots:
 
-    void UpdateTransform();  // take data in ui and put it in transform
+    void UpdateTransform( );  // take data in ui and put it in transform
+    void UpdateTransformFromMatrixDialog( vtkMatrix4x4 *mat );  // take data in ui and put it in transform
     void EditMatrixButtonToggled( bool isOn );
     void EditMatrixDialogClosed();
     void WorldMatrixButtonToggled( bool isOn );

--- a/IbisLib/gui/transformeditwidget.h
+++ b/IbisLib/gui/transformeditwidget.h
@@ -47,6 +47,7 @@ private:
     bool m_selfUpdating;
     vtkQtMatrixDialog * m_matrixDialog;
     vtkQtMatrixDialog * m_worldMatrixDialog;
+    bool m_mustUpdateTransform;
 
 public slots:
     void UpdateUi();         // take data in transform and put it in ui

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
@@ -136,13 +136,13 @@ GPU_RigidRegistration::GPU_RigidRegistration( ) :
     m_numberOfPixels(16000),
     m_orientationSelectivity(2),
     m_populationSize(0),
-    m_parentVtkTransform(0),
-    m_sourceVtkTransform(0),
-    m_targetVtkTransform(0),
-    m_resultTransform(0),
-    m_targetSpatialObjectMask(0),
-    m_itkSourceImage(0),
-    m_itkTargetImage(0)
+    m_parentVtkTransform(nullptr),
+    m_sourceVtkTransform(nullptr),
+    m_targetVtkTransform(nullptr),
+    m_resultTransform(nullptr),
+    m_targetSpatialObjectMask(nullptr),
+    m_itkSourceImage(nullptr),
+    m_itkTargetImage(nullptr)
 {
     m_samplingStrategy = SamplingStrategy::RANDOM;
 }

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
@@ -21,7 +21,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 GPU_RigidRegistrationWidget::GPU_RigidRegistrationWidget(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::GPU_RigidRegistrationWidget),
-    m_pluginInterface(0),
+    m_pluginInterface(nullptr),
     m_OptimizationRunning(false)
 {
     ui->setupUi(this);
@@ -39,6 +39,7 @@ GPU_RigidRegistrationWidget::GPU_RigidRegistrationWidget(QWidget *parent) :
 GPU_RigidRegistrationWidget::~GPU_RigidRegistrationWidget()
 {
     delete ui;
+    delete m_rigidRegistrator;
 }
 
 void GPU_RigidRegistrationWidget::SetPluginInterface( GPU_RigidRegistrationPluginInterface * ifc )

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
@@ -112,7 +112,7 @@ void GPU_RigidRegistrationWidget::on_startButton_clicked()
     if( transformObject->GetParent() )
     {
         vtkTransform * parentVtktransform = vtkTransform::SafeDownCast( transformObject->GetParent()->GetWorldTransform() );
-        Q_ASSERT_X( parentVtktransform, "VertebraRegistrationWidget::AddImageToQueue()", "Invalid transform" );
+        Q_ASSERT_X( parentVtktransform, "GPU_RigidRegistrationWidget::on_startButton_clicked()", "Invalid transform" );
         m_rigidRegistrator->SetParentVtkTransform(parentVtktransform);
     }
 

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
@@ -171,7 +171,7 @@ void vtkQtMatrixDialog::SetMatrixElements( )
         }
     }
     m_matrix->Modified();
-    emit MatrixModified();
+    emit MatrixModified( m_matrix );
 }
 
 void vtkQtMatrixDialog::InvertButtonClicked()
@@ -180,7 +180,7 @@ void vtkQtMatrixDialog::InvertButtonClicked()
     {
         m_copy_matrix->DeepCopy( m_matrix );
         m_matrix->Invert();
-        emit MatrixModified();
+        emit MatrixModified( m_matrix );
     }
 }
 
@@ -191,7 +191,7 @@ void vtkQtMatrixDialog::IdentityButtonClicked()
     {
         m_copy_matrix->DeepCopy( m_matrix );
         m_matrix->Identity();
-        emit MatrixModified();
+        emit MatrixModified( m_matrix );
     }
 }
 
@@ -202,7 +202,7 @@ void vtkQtMatrixDialog::RevertButtonClicked()
     {
         m_matrix->DeepCopy( m_copy_matrix );
         m_copy_matrix->Identity();
-        emit MatrixModified();
+        emit MatrixModified( m_matrix );
     }
     UpdateUI();
 }
@@ -276,7 +276,7 @@ void vtkQtMatrixDialog::LoadButtonClicked()
                 m_matrix->DeepCopy( mat );
             mat->Delete();
             UpdateUI();
-            emit MatrixModified();
+            emit MatrixModified( m_matrix );
         }
         else
         {

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
@@ -294,7 +294,7 @@ void vtkQtMatrixDialog::SaveButtonClicked()
 {
     Q_ASSERT( m_matrix );
 
-    QString filename = QFileDialog::getSaveFileName( this, tr("Save XFM file"), m_directory, tr("*.xfm") );
+    QString filename = QFileDialog::getSaveFileName( this, tr("Save XFM file"), m_directory, tr("*.xfm"), nullptr, QFileDialog::DontUseNativeDialog );
     if( !filename.isEmpty() )
     {
         vtkXFMWriter * writer = vtkXFMWriter::New();

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.h
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.h
@@ -51,7 +51,7 @@ public:
 
 signals:
 
-    void MatrixModified();
+    void MatrixModified( vtkMatrix4x4 * );
 
 public slots:
     


### PR DESCRIPTION
Fixed transform pipeline when edited using TransformWidget.
This is not ready to merge yet.
As I'm using a copy of the local transform matrix, the matrix dialog is not updated when the LocalTransform is updated outside of the dialog. E.g. click on Local Transform button in TransformWidget, the dialog pops up, don't close it. Run rigid registration. The numbers in the spin boxes of TransformWidget will change, but the numbers in the matrix dialog won't.
I also noticed that vtkQtMatrixDialog has some problems - freezing when you click on save. I have to investigate. 
But the transform pipline may be tested.