### PR TITLE
Add frames to US acquisition

### DIFF
--- a/IbisLib/usacquisitionobject.cpp
+++ b/IbisLib/usacquisitionobject.cpp
@@ -330,6 +330,31 @@ void USAcquisitionObject::Record()
     emit ObjectModified();
 }
 
+bool USAcquisitionObject::AddFrame(vtkImageData * image, vtkMatrix4x4 * mat, double timestamp)
+{
+    if( m_isRecording )
+        return false;
+
+    // check if frame dimensions match
+    int * dims = image->GetDimensions();
+    if( m_videoBuffer->GetNumberOfFrames() )
+    {
+        if( (dims[0] != m_defaultImageSize[0]) || (dims[1] != m_defaultImageSize[1]) )
+            return false;
+        
+    }
+    else
+    {
+        this->SetFrameAndMaskSize(dims[0], dims[1]);
+    }
+    
+    // Add the frame
+    m_videoBuffer->AddFrame(image, mat, timestamp);
+    
+    emit ObjectModified();
+    return true;
+}
+
 void USAcquisitionObject::Updated()
 {
     if( m_isRecording )

--- a/IbisLib/usacquisitionobject.h
+++ b/IbisLib/usacquisitionobject.h
@@ -133,6 +133,7 @@ public:
     void Record();
     void Stop();
     void SetCurrentFrame( int frameIndex );
+    bool AddFrame(vtkImageData *, vtkMatrix4x4 *, double);
 
     void Clear();
 


### PR DESCRIPTION
Options to add frames to USAcquisitionObject are:
- Record from a probe
- Read from files
This PR implements the possibility to add frames to an existing US acquisition