### PR TITLE
Simple solution to TransformWidget problems.

### DIFF
--- a/IbisLib/gui/transformeditwidget.h
+++ b/IbisLib/gui/transformeditwidget.h
@@ -16,6 +16,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 class vtkEventQtSlotConnect;
 class vtkQtMatrixDialog;
+class vtkMatrix4x4;
 class SceneObject;
 
 namespace Ui {
@@ -50,6 +51,7 @@ private:
 
 public slots:
     void UpdateUi();         // take data in transform and put it in ui
+    void TransformModified( vtkMatrix4x4 *mat );
 
 private slots:
 

--- a/IbisPlugins/Examples/ApplyTransformToObject/applytransformtoobjectwidget.cpp
+++ b/IbisPlugins/Examples/ApplyTransformToObject/applytransformtoobjectwidget.cpp
@@ -38,7 +38,7 @@ void ApplyTransformToObjectWidget::on_transformPushButton_clicked()
     m_matrixDialog->setAttribute( Qt::WA_DeleteOnClose );
     m_matrixDialog->SetMatrix( localTransform->GetMatrix() );
     m_matrixDialog->show();
-    connect( m_matrixDialog, SIGNAL(MatrixModified()), m_selectedObject, SLOT(NotifyTransformChanged()) );
+    connect( m_matrixDialog, SIGNAL(MatrixModified( vtkMatrix4x4* )), m_selectedObject, SLOT(NotifyTransformChanged()) );
     connect( m_matrixDialog, SIGNAL(destroyed()), this, SLOT(EditMatrixDialogClosed()) );
 }
 

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
@@ -171,7 +171,7 @@ void vtkQtMatrixDialog::SetMatrixElements( )
         }
     }
     m_matrix->Modified();
-    emit MatrixModified();
+    emit MatrixModified( m_matrix );
 }
 
 void vtkQtMatrixDialog::InvertButtonClicked()
@@ -180,7 +180,7 @@ void vtkQtMatrixDialog::InvertButtonClicked()
     {
         m_copy_matrix->DeepCopy( m_matrix );
         m_matrix->Invert();
-        emit MatrixModified();
+        emit MatrixModified( m_matrix );
     }
 }
 
@@ -191,7 +191,7 @@ void vtkQtMatrixDialog::IdentityButtonClicked()
     {
         m_copy_matrix->DeepCopy( m_matrix );
         m_matrix->Identity();
-        emit MatrixModified();
+        emit MatrixModified( m_matrix );
     }
 }
 
@@ -202,7 +202,7 @@ void vtkQtMatrixDialog::RevertButtonClicked()
     {
         m_matrix->DeepCopy( m_copy_matrix );
         m_copy_matrix->Identity();
-        emit MatrixModified();
+        emit MatrixModified( m_matrix );
     }
     UpdateUI();
 }
@@ -276,7 +276,7 @@ void vtkQtMatrixDialog::LoadButtonClicked()
                 m_matrix->DeepCopy( mat );
             mat->Delete();
             UpdateUI();
-            emit MatrixModified();
+            emit MatrixModified( m_matrix );
         }
         else
         {

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.h
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.h
@@ -51,7 +51,7 @@ public:
 
 signals:
 
-    void MatrixModified();
+    void MatrixModified( vtkMatrix4x4* );
 
 public slots:
     


### PR DESCRIPTION
Instead of using directly matrix of LocalTransform of the object use a copy in vtkQtMatrixDialog and in TransformEditWidget::UpdateTransform() then use SetMatrix to put the modified matrix in the LocalTransform.
Remains one problem - if you have vtkMatrixDialog open and you change LocalTransform outside of that dialog, changes will not show. For now just close the dialog when not needed, I'll try to fix it.

