### PR TITLE
All calls to QFileDialog::xxx get option QFileDialog::DontUseNativeDialog

### DIFF
--- a/IbisLib/application.cpp
+++ b/IbisLib/application.cpp
@@ -680,7 +680,7 @@ QString Application::GetFileNameOpen( const QString & caption, const QString & d
     if (m_mainWindow)
         parent = m_mainWindow;
     bool running = PreModalDialog();
-    QString filename = QFileDialog::getOpenFileName( parent, caption, dir, filter );
+    QString filename = QFileDialog::getOpenFileName( parent, caption, dir, filter, nullptr, QFileDialog::DontUseNativeDialog );
     if( running )
         PostModalDialog();
     return filename;
@@ -690,7 +690,7 @@ QString Application::GetFileNameSave( const QString & caption, const QString & d
 {
     Q_ASSERT_X( m_mainWindow, "Application::GetFileNameSave()", "MainWindow was not set" );
     bool running = PreModalDialog();
-    QString filename = QFileDialog::getSaveFileName( m_mainWindow, caption, dir, filter );
+    QString filename = QFileDialog::getSaveFileName( m_mainWindow, caption, dir, filter, nullptr, QFileDialog::DontUseNativeDialog );
     if( running )
         PostModalDialog();
     return filename;
@@ -701,7 +701,7 @@ QString Application::GetExistingDirectory( const QString & caption, const QStrin
     Q_ASSERT_X( m_mainWindow, "Application::GetExistingDirectory()", "MainWindow was not set" );
     bool running = PreModalDialog();
     QString dirname = QFileDialog::getExistingDirectory( m_mainWindow, caption, dir, QFileDialog::ShowDirsOnly
-                                                         | QFileDialog::DontResolveSymlinks );
+                                                         | QFileDialog::DontResolveSymlinks | QFileDialog::DontUseNativeDialog );
     if( running )
         PostModalDialog();
     return dirname;

--- a/IbisLib/gui/exportacquisitiondialog.cpp
+++ b/IbisLib/gui/exportacquisitiondialog.cpp
@@ -42,7 +42,7 @@ void ExportAcquisitionDialog::SetUSAcquisitionObject( USAcquisitionObject * acq 
 void ExportAcquisitionDialog::on_browsePushButton_clicked( )
 {
     Q_ASSERT( m_acquisitionObject );
-    QString outputDir = QFileDialog::getExistingDirectory( this, "Output Folder", m_acquisitionObject->GetManager()->GetSceneDirectory() );
+    QString outputDir = QFileDialog::getExistingDirectory( this, "Output Folder", m_acquisitionObject->GetManager()->GetSceneDirectory(),  QFileDialog::DontUseNativeDialog );
     ui->outputDirLineEdit->setText( outputDir );
 }
 

--- a/IbisPlugins/CameraCalibration/cameracalibrationsidepanelwidget.cpp
+++ b/IbisPlugins/CameraCalibration/cameracalibrationsidepanelwidget.cpp
@@ -155,7 +155,7 @@ void CameraCalibrationSidePanelWidget::on_exportCalibrationDataButton_clicked()
 {
     Q_ASSERT( m_pluginInterface );
 
-    QString dir = QFileDialog::getExistingDirectory( this, "Choose directory to export calibration data", QDir::homePath() );
+    QString dir = QFileDialog::getExistingDirectory( this, "Choose directory to export calibration data", QDir::homePath(), QFileDialog::DontUseNativeDialog );
     if( !dir.isEmpty() )
     {
         QProgressDialog * dlg = m_pluginInterface->GetIbisAPI()->StartProgress( 100, "Exporting calibration data..." );
@@ -168,7 +168,7 @@ void CameraCalibrationSidePanelWidget::on_importDataButton_clicked()
 {
     Q_ASSERT( m_pluginInterface );
 
-    QString dir = QFileDialog::getExistingDirectory( this, "Choose directory where calibration data is located", QDir::homePath() );
+    QString dir = QFileDialog::getExistingDirectory( this, "Choose directory where calibration data is located", QDir::homePath(), QFileDialog::DontUseNativeDialog );
     if( !dir.isEmpty() )
     {
         m_pluginInterface->ImportCalibrationData( dir );

--- a/IbisPlugins/SequenceIO/sequenceiowidget.cpp
+++ b/IbisPlugins/SequenceIO/sequenceiowidget.cpp
@@ -601,7 +601,7 @@ void SequenceIOWidget::on_exportButton_clicked()
         return;
     }
 
-    m_outputFilename = QFileDialog::getSaveFileName(this, tr("Export Ultrasound Sequence"), "", tr("Sequence (*.igs.mha);;All files (*)"));
+    m_outputFilename = QFileDialog::getSaveFileName(this, tr("Export Ultrasound Sequence"), "", tr("Sequence (*.igs.mha);;All files (*)"), nullptr, QFileDialog::DontUseNativeDialog);
     if( !m_outputFilename.isEmpty() )
     {
         this->StartProgress(usAcquisitionObject->GetNumberOfSlices() * 2, tr("Ultrasound sequence IO"));
@@ -634,7 +634,7 @@ void SequenceIOWidget::on_openSequenceButton_clicked()
     IbisAPI * ibisApi = m_pluginInterface->GetIbisAPI();
 
     QString filename = QFileDialog::getOpenFileName(this, tr("Open Sequence File"), ibisApi->GetSceneDirectory(),
-                                                    "Sequence file (*.igs.mha);; All files(*)");
+                                                    "Sequence file (*.igs.mha);; All files(*)", nullptr, QFileDialog::DontUseNativeDialog);
     
     QFileInfo fi(filename);
     if( fi.isFile() )

--- a/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
+++ b/IbisVTK/vtkQt/vtkQtMatrixDialog.cpp
@@ -294,7 +294,7 @@ void vtkQtMatrixDialog::SaveButtonClicked()
 {
     Q_ASSERT( m_matrix );
 
-    QString filename = QFileDialog::getSaveFileName( this, tr("Save XFM file"), m_directory, tr("*.xfm") );
+    QString filename = QFileDialog::getSaveFileName( this, tr("Save XFM file"), m_directory, tr("*.xfm"), nullptr, QFileDialog::DontUseNativeDialog );
     if( !filename.isEmpty() )
     {
         vtkXFMWriter * writer = vtkXFMWriter::New();


### PR DESCRIPTION
There were still dialogs that would not show and freeze ibis. E.g. in vtkQtMatrixDialog save dialog, in CameraCalibration Import/Export dialogs.
Tested on Linux and partly on Windows. Bug was not reported.
