### PR TITLE
Fixed removing scene objects, issue #246

### DIFF
--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -806,6 +806,8 @@ void SceneManager::RemoveObject( SceneObject * object )
 
     // remove all children
     this->RemoveAllChildrenObjects(object);
+    // removing children may change index on the ALLObjects list
+    indexAll = this->AllObjects.indexOf( object );
 
     // simtodo : assert position != -1
     int position = object->GetObjectListableIndex();


### PR DESCRIPTION
Removing children may change the position of the parent on the list of all objects, we have to find it again after removal.
