### PR TITLE
Bug #391 - removing TrackedSceneObject

### DIFF
--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -18,6 +18,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "usprobeobject.h"
 #include "cameraobject.h"
 #include "polydataobject.h"
+#include "trackedsceneobject.h"
 
 #include <QDir>
 #include <QMenu>
@@ -148,6 +149,7 @@ void IbisHardwareIGSIO::ClearConfig()
         delete tool;
     }
     m_tools.clear();
+    m_deviceToolAssociations.clear();
     ShutDownLocalServers();
 }
 
@@ -211,6 +213,16 @@ void IbisHardwareIGSIO::RemoveToolObjectsFromScene()
 {
     foreach( Tool * tool, m_tools )
     {
+        TrackedSceneObject * toolObject = TrackedSceneObject::SafeDownCast( tool->sceneObject );
+// This next 3 calls will mark the object as not driven by hardware, removing it from the list of tracked objects.
+// We also mark it as not managed by tracker and not managed by system.
+// We have to remember that the object is known to the SceneManager until it is removed from the list of all objects.
+// Before the final removal from the list there are many callbacks that may access the object and we do not want it
+// to be treated as a special object.
+        toolObject->SetHardwareModule( nullptr );
+        toolObject->SetObjectManagedBySystem( false );
+        toolObject->SetObjectManagedByTracker( false );
+// Finally we remove the object
         GetIbisAPI()->RemoveObject( tool->sceneObject );
     }
 }

--- a/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
+++ b/IbisHardwareIGSIO/ibishardwareIGSIO.cpp
@@ -18,7 +18,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "usprobeobject.h"
 #include "cameraobject.h"
 #include "polydataobject.h"
-#include "trackedsceneobject.h"
 
 #include <QDir>
 #include <QMenu>
@@ -213,16 +212,6 @@ void IbisHardwareIGSIO::RemoveToolObjectsFromScene()
 {
     foreach( Tool * tool, m_tools )
     {
-        TrackedSceneObject * toolObject = TrackedSceneObject::SafeDownCast( tool->sceneObject );
-// This next 3 calls will mark the object as not driven by hardware, removing it from the list of tracked objects.
-// We also mark it as not managed by tracker and not managed by system.
-// We have to remember that the object is known to the SceneManager until it is removed from the list of all objects.
-// Before the final removal from the list there are many callbacks that may access the object and we do not want it
-// to be treated as a special object.
-        toolObject->SetHardwareModule( nullptr );
-        toolObject->SetObjectManagedBySystem( false );
-        toolObject->SetObjectManagedByTracker( false );
-// Finally we remove the object
         GetIbisAPI()->RemoveObject( tool->sceneObject );
     }
 }

--- a/IbisLib/trackedsceneobject.cpp
+++ b/IbisLib/trackedsceneobject.cpp
@@ -179,3 +179,15 @@ void TrackedSceneObject::InternalUpdateWorldTransform()
         m_uncalibratedWorldTransform->Concatenate( Parent->GetWorldTransform() );
     m_uncalibratedWorldTransform->Concatenate( m_transform );
 }
+
+void TrackedSceneObject::ObjectAboutToBeRemovedFromScene()
+{
+    // We mark the object as not driven by hardware, removing it from the list of tracked objects.
+    // We also mark it as not managed by tracker and not managed by system.
+    // We have to remember that the object is known to the SceneManager until it is removed from the list of all objects.
+    // Before the final removal from the list there are many callbacks that may access the object and we do not want it
+    // to be treated as a special object.
+    this->SetHardwareModule( nullptr );
+    this->SetObjectManagedBySystem( false );
+    this->SetObjectManagedByTracker( false );
+}

--- a/IbisLib/trackedsceneobject.h
+++ b/IbisLib/trackedsceneobject.h
@@ -59,6 +59,7 @@ public:
 protected:
 
     virtual void InternalUpdateWorldTransform();
+    virtual void ObjectAboutToBeRemovedFromScene() override;
 
     HardwareModule * m_hardwareModule;
 

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
@@ -73,7 +73,7 @@ protected:
 
     // SceneObject protected overloads
     virtual void ObjectAddedToScene();
-    virtual void ObjectAboutToBeRemovedFromScene();
+    virtual void ObjectAboutToBeRemovedFromScene() override;
 
     virtual void InternalPostSceneRead();
     virtual void Hide();


### PR DESCRIPTION
SceneManager::RemoveObject() sends signal ObjectRemoved() before removing the object from the list of all SceneObjects. This is done in order to allow each type of object to do some cleaning. We use this opportunity to call ObjectAboutToBeRemovedFromScene() in TrackedSceneObject to remove properties that make this object special.
