### PR TITLE
Registration mask

### DIFF
--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
@@ -290,7 +290,7 @@ void GPU_RigidRegistration::runRegistration()
     metric->SetPercentile( percentile );
     metric->SetN( orientationSelectivity );
     metric->SetComputeMask( m_useMask );
-    metric->SetMaskThreshold( 0.5 );
+    metric->SetMaskThreshold(0.05);
     metric->SetGradientScale( gradientScale );
     GPUCostFunctionPointer costFunction = GPUCostFunctionType::New();
     costFunction->SetGPUMetric( metric );

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
@@ -16,6 +16,8 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <itkTimeProbesCollectorBase.h>
 #include <sstream>
 
+#include <itkImageFileReader.h>
+
 class CommandIterationUpdateOpenCL : public itk::Command
 {
 public:

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
@@ -221,7 +221,7 @@ void GPU_RigidRegistration::runRegistration()
     {
         *this->m_debugStream << "Using mask" << std::endl;
         metric->SetFixedImageMaskSpatialObject(m_targetSpatialObjectMask);
-        metric->SetUseImageMask(true);
+        metric->SetUseFixedImageMask(true);
     }
 
     // Initialize Transform

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.cpp
@@ -136,13 +136,14 @@ GPU_RigidRegistration::GPU_RigidRegistration( ) :
     m_numberOfPixels(16000),
     m_orientationSelectivity(2),
     m_populationSize(0),
-    m_parentVtkTransform(0),
-    m_sourceVtkTransform(0),
-    m_targetVtkTransform(0),
-    m_resultTransform(0),
-    m_targetSpatialObjectMask(0),
-    m_itkSourceImage(0),
-    m_itkTargetImage(0)
+    m_parentVtkTransform(nullptr),
+    m_sourceVtkTransform(nullptr),
+    m_targetVtkTransform(nullptr),
+    m_resultTransform(nullptr),
+    m_targetSpatialObjectMask(nullptr),
+    m_sourceSpatialObjectMask(nullptr),
+    m_itkSourceImage(nullptr),
+    m_itkTargetImage(nullptr)
 {
     m_samplingStrategy = SamplingStrategy::RANDOM;
 }
@@ -219,9 +220,16 @@ void GPU_RigidRegistration::runRegistration()
 
     if ( m_targetSpatialObjectMask )
     {
-        *this->m_debugStream << "Using mask" << std::endl;
+        *this->m_debugStream << "Using fixed mask" << std::endl;
         metric->SetFixedImageMaskSpatialObject(m_targetSpatialObjectMask);
         metric->SetUseFixedImageMask(true);
+    }
+
+    if( m_sourceSpatialObjectMask )
+    {
+        *this->m_debugStream << "Using moving mask" << std::endl;
+        metric->SetMovingImageMaskSpatialObject(m_sourceSpatialObjectMask);
+        metric->SetUseMovingImageMask(true);
     }
 
     // Initialize Transform

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.h
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistration.h
@@ -88,6 +88,7 @@ public:
 
 
     void SetTargetMask(ImageMaskPointer mask) { this->m_targetSpatialObjectMask = mask;}
+    void SetSourceMask(ImageMaskPointer mask) { this->m_sourceSpatialObjectMask = mask; }
 
 private:
 
@@ -102,6 +103,7 @@ private:
     IbisItkFloat3ImageType::Pointer m_itkTargetImage;
 
     ImageMaskPointer m_targetSpatialObjectMask;
+    ImageMaskPointer m_sourceSpatialObjectMask;
 
     vtkTransform * m_sourceVtkTransform;
     vtkTransform * m_targetVtkTransform;

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
@@ -111,7 +111,7 @@ void GPU_RigidRegistrationWidget::on_startButton_clicked()
     if( transformObject->GetParent() )
     {
         vtkTransform * parentVtktransform = vtkTransform::SafeDownCast( transformObject->GetParent()->GetWorldTransform() );
-        Q_ASSERT_X( parentVtktransform, "VertebraRegistrationWidget::AddImageToQueue()", "Invalid transform" );
+        Q_ASSERT_X( parentVtktransform, "GPU_RigidRegistrationWidget::AddImageToQueue()", "Invalid transform" );
         rigidRegistrator->SetParentVtkTransform(parentVtktransform);
     }
 

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.cpp
@@ -32,8 +32,6 @@ GPU_RigidRegistrationWidget::GPU_RigidRegistrationWidget(QWidget *parent) :
     connect(ui->debugCheckBox, SIGNAL(stateChanged(int)), this, SLOT(on_debugCheckBox_clicked()));
     ui->registrationOutputTextEdit->hide();
 
-    m_rigidRegistrator = new GPU_RigidRegistration();
-
 }
 
 GPU_RigidRegistrationWidget::~GPU_RigidRegistrationWidget()
@@ -91,34 +89,35 @@ void GPU_RigidRegistrationWidget::on_startButton_clicked()
 
     m_registrationTimer.start();
 
+    GPU_RigidRegistration * rigidRegistrator = new GPU_RigidRegistration();
     // Initialize parameters
-    m_rigidRegistrator->SetNumberOfPixels( ui->numebrOfPixelsDial->value() );
-    m_rigidRegistrator->SetOrientationSelectivity( ui->selectivityDial->value() );
-    m_rigidRegistrator->SetPopulationSize( ui->populationSizeDial->value() );
-    m_rigidRegistrator->SetInitialSigma( ui->initialSigmaComboBox->itemData( ui->initialSigmaComboBox->currentIndex() ).toDouble() );
-    m_rigidRegistrator->SetPercentile( ui->percentileComboBox->itemData( ui->percentileComboBox->currentIndex() ).toDouble() );
-    m_rigidRegistrator->SetUseMask( ui->computeMaskCheckBox->isChecked() );
-    m_rigidRegistrator->SetDebug( debug, &debugStringStream);
+    rigidRegistrator->SetNumberOfPixels( ui->numebrOfPixelsDial->value() );
+    rigidRegistrator->SetOrientationSelectivity( ui->selectivityDial->value() );
+    rigidRegistrator->SetPopulationSize( ui->populationSizeDial->value() );
+    rigidRegistrator->SetInitialSigma( ui->initialSigmaComboBox->itemData( ui->initialSigmaComboBox->currentIndex() ).toDouble() );
+    rigidRegistrator->SetPercentile( ui->percentileComboBox->itemData( ui->percentileComboBox->currentIndex() ).toDouble() );
+    rigidRegistrator->SetUseMask( ui->computeMaskCheckBox->isChecked() );
+    rigidRegistrator->SetDebug( debug, &debugStringStream);
 
     // Set image inputs
-    m_rigidRegistrator->SetItkSourceImage( itkSourceImage );
-    m_rigidRegistrator->SetItkTargetImage( itkTargetImage );
+    rigidRegistrator->SetItkSourceImage( itkSourceImage );
+    rigidRegistrator->SetItkTargetImage( itkTargetImage );
 
     // Set transform inputs
-    m_rigidRegistrator->SetVtkTransform( vtktransform );
-    m_rigidRegistrator->SetSourceVtkTransform( sourceVtkTransform );
-    m_rigidRegistrator->SetTargetVtkTransform( targetVtkTransform );
+    rigidRegistrator->SetVtkTransform( vtktransform );
+    rigidRegistrator->SetSourceVtkTransform( sourceVtkTransform );
+    rigidRegistrator->SetTargetVtkTransform( targetVtkTransform );
 
     if( transformObject->GetParent() )
     {
         vtkTransform * parentVtktransform = vtkTransform::SafeDownCast( transformObject->GetParent()->GetWorldTransform() );
         Q_ASSERT_X( parentVtktransform, "VertebraRegistrationWidget::AddImageToQueue()", "Invalid transform" );
-        m_rigidRegistrator->SetParentVtkTransform(parentVtktransform);
+        rigidRegistrator->SetParentVtkTransform(parentVtktransform);
     }
 
     // Run registration
 //    transformObject->StartModifyingTransform();
-    m_rigidRegistrator->runRegistration();
+    rigidRegistrator->runRegistration();
 //    transformObject->FinishModifyingTransform();
 
     m_OptimizationRunning = true;

--- a/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.h
+++ b/IbisPlugins/GPU_RigidRegistration/gpu_rigidregistrationwidget.h
@@ -53,7 +53,6 @@ private:
 
     Ui::GPU_RigidRegistrationWidget * ui;
     GPU_RigidRegistrationPluginInterface * m_pluginInterface;
-    GPU_RigidRegistration * m_rigidRegistrator;
     QElapsedTimer m_registrationTimer;
     bool          m_OptimizationRunning;
 

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/GPUOrientationMatchingMatrixTransformationSparseMaskKernel.cl
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/GPUOrientationMatchingMatrixTransformationSparseMaskKernel.cl
@@ -48,25 +48,32 @@ __kernel void OrientationMatchingMetricSparseMask(
   
   /* Interpolated Moving Gradient */
   REAL4 movingGrad = read_imagef(mgImage, mySampler, cId);  
+  REAL metricValue;
 
-  REAL4 rctX = rigidContext[3];
-  REAL4 rctY = rigidContext[4];
-  REAL4 rctZ = rigidContext[5];  
+  if( (!USEMASK) || (USEMASK && (movingGrad.w > 0.0f)) )
+  {
+      REAL4 rctX = rigidContext[3];
+      REAL4 rctY = rigidContext[4];
+      REAL4 rctZ = rigidContext[5];
 
-  /* Transformed Moving Gradient */
-  REAL4 trMovingGrad = (REAL4)(0.0f, 0.0f, 0.0f, 0.0f);
-  trMovingGrad.x = dot(rctX, movingGrad);
-  trMovingGrad.y = dot(rctY, movingGrad);
-  trMovingGrad.z = dot(rctZ, movingGrad);       
+      /* Transformed Moving Gradient */
+      REAL4 trMovingGrad = (REAL4)(0.0f, 0.0f, 0.0f, 0.0f);
+      trMovingGrad.x = dot(rctX, movingGrad);
+      trMovingGrad.y = dot(rctY, movingGrad);
+      trMovingGrad.z = dot(rctZ, movingGrad);
 
-  REAL4 trMovingGradN = normalize(trMovingGrad);
+      REAL4 trMovingGradN = normalize(trMovingGrad);
 
-  REAL4 fixedGrad = g_fg[gidx];      
-  REAL4 fixedGradN = normalize(fixedGrad);
+      REAL4 fixedGrad = g_fg[gidx];
+      REAL4 fixedGradN = normalize(fixedGrad);
 
-  REAL innerProduct = dot(fixedGradN, trMovingGradN);
-  REAL metricValue = pown(innerProduct, SEL);
-  
+      REAL innerProduct = dot(fixedGradN, trMovingGradN);
+      metricValue = pown(innerProduct, SEL);
+  }
+  else
+  {
+      metricValue = 0.0f;
+  }
   metricAccums[lid] = metricValue;  
   
   barrier(CLK_LOCAL_MEM_FENCE);

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.h
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.h
@@ -176,10 +176,14 @@ public:
 
   itkSetMacro(FixedImageMaskSpatialObject, FixedImageMaskSpatialObjectPointer);
   itkSetMacro(MovingImageMaskSpatialObject, MovingImageMaskSpatialObjectPointer);
-  itkSetMacro(UseFixedImageMask, bool)
+  itkSetMacro(UseFixedImageMask, bool);
+  itkSetMacro(UseMovingImageMask, bool);
 
   using FixedImageMaskIteratorType = itk::ImageRegionConstIteratorWithIndex< FixedImageMaskType >;
   using FixedImageIteratorType = itk::ImageRegionConstIteratorWithIndex< FixedImageType >;
+  
+  using MovingImageMaskIteratorType = itk::ImageRegionConstIteratorWithIndex< MovingImageMaskType >;
+  using MovingImageIteratorType = itk::ImageRegionConstIteratorWithIndex< MovingImageType >;
 
   void Update(void);
 
@@ -230,7 +234,7 @@ protected:
   cl_mem                      m_MovingImageGradientGPUBuffer;
   cl_mem                      m_MovingImageGradientGPUImage;
 
-  cl_mem                      m_MaskImageGPUBuffer;
+  cl_mem                      m_MovingImageMaskGPUBuffer;
 
   InternalRealType              m_MetricValue;
 
@@ -276,8 +280,10 @@ protected:
   FixedImageMaskSpatialObjectPointer     m_FixedImageMaskSpatialObject;
   MovingImageMaskSpatialObjectPointer    m_MovingImageMaskSpatialObject;
 
-  // m_UseImageMask: when true samples gradients from masked region in FixedImage
+  // m_UseFixedImageMask: when true samples gradients from masked region in FixedImage
   bool                                   m_UseFixedImageMask;
+  // m_UseMovingImageMask: when true samples gradients from masked region in MovingImage
+  bool                                   m_UseMovingImageMask;
 
   InternalRealType *          m_cpuMovingImageBuffer;
   cl_mem                      m_MovingGPUImage;

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.h
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.h
@@ -169,8 +169,14 @@ public:
   using FixedImageMaskType = typename FixedImageMaskSpatialObjectType::ImageType;
   using FixedImageMaskPointer = typename FixedImageMaskType::Pointer;
 
+  using MovingImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< MovingImageDimension >;
+  using MovingImageMaskSpatialObjectPointer = typename MovingImageMaskSpatialObjectType::Pointer;
+  using MovingImageMaskType = typename MovingImageMaskSpatialObjectType::ImageType;
+  using MovingImageMaskPointer = typename MovingImageMaskType::Pointer;
+
   itkSetMacro(FixedImageMaskSpatialObject, FixedImageMaskSpatialObjectPointer);
-  itkSetMacro(UseImageMask, bool)
+  itkSetMacro(MovingImageMaskSpatialObject, MovingImageMaskSpatialObjectPointer);
+  itkSetMacro(UseFixedImageMask, bool)
 
   using FixedImageMaskIteratorType = itk::ImageRegionConstIteratorWithIndex< FixedImageMaskType >;
   using FixedImageIteratorType = itk::ImageRegionConstIteratorWithIndex< FixedImageType >;
@@ -201,6 +207,7 @@ protected:
   unsigned int      m_N;
   double            m_GradientScale;
 
+  // m_ComputeMask: when true only select strong gradient magnitudes
   bool              m_ComputeMask;
   double            m_MaskThreshold;
 
@@ -267,7 +274,10 @@ protected:
   cl_uint m_NumberOfDevices, m_NumberOfPlatforms;
 
   FixedImageMaskSpatialObjectPointer     m_FixedImageMaskSpatialObject;
-  bool                                   m_UseImageMask;
+  MovingImageMaskSpatialObjectPointer    m_MovingImageMaskSpatialObject;
+
+  // m_UseImageMask: when true samples gradients from masked region in FixedImage
+  bool                                   m_UseFixedImageMask;
 
   InternalRealType *          m_cpuMovingImageBuffer;
   cl_mem                      m_MovingGPUImage;

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.h
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.h
@@ -32,6 +32,9 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 #include <itkImageMaskSpatialObject.h>
 #include <itkImageRegionIteratorWithIndex.h>
+#include <itkChangeInformationImageFilter.h>
+
+#include <itkImageFileWriter.h>
 
 namespace itk
 {
@@ -168,11 +171,13 @@ public:
   using FixedImageMaskSpatialObjectPointer = typename FixedImageMaskSpatialObjectType::Pointer;
   using FixedImageMaskType = typename FixedImageMaskSpatialObjectType::ImageType;
   using FixedImageMaskPointer = typename FixedImageMaskType::Pointer;
+  using FixedImageMaskPixelType = typename FixedImageMaskType::PixelType;
 
   using MovingImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< MovingImageDimension >;
   using MovingImageMaskSpatialObjectPointer = typename MovingImageMaskSpatialObjectType::Pointer;
   using MovingImageMaskType = typename MovingImageMaskSpatialObjectType::ImageType;
   using MovingImageMaskPointer = typename MovingImageMaskType::Pointer;
+  using MovingImageMaskPixelType = typename MovingImageMaskType::PixelType;
 
   itkSetMacro(FixedImageMaskSpatialObject, FixedImageMaskSpatialObjectPointer);
   itkSetMacro(MovingImageMaskSpatialObject, MovingImageMaskSpatialObjectPointer);
@@ -235,6 +240,7 @@ protected:
   cl_mem                      m_MovingImageGradientGPUImage;
 
   cl_mem                      m_MovingImageMaskGPUBuffer;
+  cl_mem                      m_FixedImageMaskGPUBuffer;
 
   InternalRealType              m_MetricValue;
 

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.h
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.h
@@ -32,9 +32,6 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 
 #include <itkImageMaskSpatialObject.h>
 #include <itkImageRegionIteratorWithIndex.h>
-#include <itkChangeInformationImageFilter.h>
-
-#include <itkImageFileWriter.h>
 
 namespace itk
 {

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
@@ -50,7 +50,7 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
 
   m_GradientScale = 1.0;
 
-  m_ComputeMask = false;
+  m_ComputeMask = true;
   m_MaskThreshold = 0.0;
 
   m_FixedImage = nullptr;
@@ -61,8 +61,9 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
   m_Transform = nullptr;
   m_MetricValue = 0;
 
-  m_UseImageMask = false;
-  m_FixedImageMaskSpatialObject = 0;
+  m_UseFixedImageMask = false;
+  m_FixedImageMaskSpatialObject = nullptr;
+  m_MovingImageMaskSpatialObject = nullptr;
   SetSamplingStrategyToGrid();
 
   m_MovingGPUImage = nullptr;
@@ -320,7 +321,7 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
   }
 
   std::string kernelname = "SeparableNeighborOperatorFilter";
-  if((m_ComputeMask) & (!m_UseImageMask))
+  if((m_ComputeMask) & (!m_UseFixedImageMask))
   {
       kernelname = "SeparableNeighborOperatorFilterThresholder";
   }
@@ -372,7 +373,7 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
   errid = clFinish(m_CommandQueue[0]);
   OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
 
-  if(m_UseImageMask)
+  if( m_UseFixedImageMask )
      {
      typename FixedImageMaskType::ConstPointer constFixedImage = m_FixedImageMaskSpatialObject->GetImage();
      FixedImageMaskIteratorType imageIterator( constFixedImage, constFixedImage->GetRequestedRegion() );
@@ -942,14 +943,14 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
     itkExceptionMacro(<< "Transform is not set." );
     }
 
-    if(m_UseImageMask)
+    if(m_UseFixedImageMask)
     {
     if(!m_FixedImageMaskSpatialObject)
        {
        itkWarningMacro(<< "m_FixedImageMaskSpatialObject was not found, UseImageMask is set to OFF" );
-       m_UseImageMask = false;
+       m_UseFixedImageMask = false;
        }
-    m_ComputeMask = true;
+    //m_ComputeMask = true;
     }
 
     if(!m_MovingImageGradientGPUImage)

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
@@ -26,6 +26,10 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include "GPUDiscreteGaussianGradientImageFilter.h"
 #include "GPUOrientationMatchingMatrixTransformationSparseMaskKernel.h"
 
+#ifdef __OUTPUT_GRADIENTS__
+#include <itkImageFileWriter.h>
+#endif
+
 namespace itk
 {
 /**

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
@@ -62,6 +62,7 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
   m_MetricValue = 0;
 
   m_UseFixedImageMask = false;
+  m_UseMovingImageMask = false;
   m_FixedImageMaskSpatialObject = nullptr;
   m_MovingImageMaskSpatialObject = nullptr;
   SetSamplingStrategyToGrid();

--- a/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
+++ b/IbisPlugins/GPU_RigidRegistration/itkRegistrationOpenCL/itkGPUOrientationMatchingMatrixTransformationSparseMask.hxx
@@ -682,11 +682,14 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
 
   cl_int errid;
 
-  typedef typename MovingImageMaskType::PixelType    MovingImageMaskPixelType;
-  m_MovingImageMaskGPUBuffer = clCreateBuffer(m_Context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
-      sizeof(MovingImageMaskPixelType) * nbrOfPixelsInMovingImage,
-      (MovingImageMaskPixelType *) m_MovingImageMaskSpatialObject->GetImage()->GetBufferPointer(), &errid);
-  OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
+  if( m_UseMovingImageMask )
+  {
+      typedef typename MovingImageMaskType::PixelType    MovingImageMaskPixelType;
+      m_MovingImageMaskGPUBuffer = clCreateBuffer(m_Context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+          sizeof(MovingImageMaskPixelType) * nbrOfPixelsInMovingImage,
+          (MovingImageMaskPixelType *)m_MovingImageMaskSpatialObject->GetImage()->GetBufferPointer(), &errid);
+      OpenCLCheckError(errid, __FILE__, __LINE__, ITK_LOCATION);
+  }
 
   m_MovingImageGPUBuffer = clCreateBuffer(m_Context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
                           sizeof(MovingImagePixelType)*nbrOfPixelsInMovingImage,
@@ -989,6 +992,9 @@ GPUOrientationMatchingMatrixTransformationSparseMask< TFixedImage, TMovingImage 
           std::cout << "Preparing to Compute Gradients.." << std::endl;
        this->ComputeFixedImageGradient();
        this->ComputeMovingImageGradient();
+       {
+           // TODOMamarz: add test code here
+       }
     }
 
     if(m_TransformMatrix == m_Transform->GetMatrix() && m_TransformOffset == m_TransformOffset)

--- a/IbisPlugins/PedicleScrewNavigation/itkWeightRegistration/itkGPU3DRigidSimilarityWeightMetric.h
+++ b/IbisPlugins/PedicleScrewNavigation/itkWeightRegistration/itkGPU3DRigidSimilarityWeightMetric.h
@@ -252,7 +252,7 @@ public:
           if (m_FixedSpatialObjectImageMask)
              {
              m_GPUOrientationMetric->SetFixedImageMaskSpatialObject(m_FixedSpatialObjectImageMask);
-             m_GPUOrientationMetric->SetUseImageMask(true);
+             m_GPUOrientationMetric->SetUseFixedImageMask(true);
              }
           m_GPUOrientationMetric->SetSamplingStrategy(m_OrientationSamplingStrategy);
           m_GPUOrientationMetric->SetNumberOfPixels( m_OrientationNumberOfPixels );


### PR DESCRIPTION
- Add masking feature for registration:
   - Fixed image mask
   - Moving image mask
- Change GPURigidRegistration to local variable
- m_MaskThreshold and SetMaskThreshold() were not used before (hardcoded to 0.001). They are now used to threshold image intensity when computing gradients
-  Unified OpenCL gradient kernels under "SeparableNeighborOperatorFilterWithMask" to return (gx, gy, gz, mask), where (gx, gy, gz) are gradient components and: 
   - mask = -1, if the voxel is outside the specified mask
   - mask = 0, if the intensity is below the threshold
   - mask = 1, otherwise

TODO: 
- The UI does not allow to input mask images. For now, it can only be done internally.
- Need to add validity checks to make sure
   - masks are not all zeros 
   - image and mask sizes are consistent
- Fixed and Moving image intensity need to be normalized between [0,1] before gradient computation
 