### PR TITLE
Disallow editing LocalTransform of GeneratedSurface

### DIFF
--- a/IbisPlugins/ContourSurface/generatedsurface.cpp
+++ b/IbisPlugins/ContourSurface/generatedsurface.cpp
@@ -40,6 +40,7 @@ GeneratedSurface::GeneratedSurface()
     m_gaussianSmoothing = false;
     m_reductionPercent = 0;
     AllowChangeParent = false;
+    AllowManualTransformEdit = false;
 }
 
 GeneratedSurface::~GeneratedSurface()


### PR DESCRIPTION
Generated surface inherits transforms from its parent.