### PR TITLE
Fix Landmark  Registration Bugs 465 and 455 

### DIFF
--- a/IbisLib/gui/quadviewwindow.cpp
+++ b/IbisLib/gui/quadviewwindow.cpp
@@ -203,7 +203,7 @@ void QuadViewWindow::SetSceneManager( SceneManager * man )
     connect( man, SIGNAL(ShowGenericLabelText()), this, SLOT(OnShowGenericLabelText()) );
 
     m_sceneManager->PreDisplaySetup();
-//        this->PlaceCornerText(); temporarily blocked
+    this->PlaceCornerText(); // It was temporarily blocked, seems to work now.
 }
 
 void QuadViewWindow::AddBottomWidget( QWidget * w )

--- a/IbisLib/gui/quadviewwindow.cpp
+++ b/IbisLib/gui/quadviewwindow.cpp
@@ -203,7 +203,7 @@ void QuadViewWindow::SetSceneManager( SceneManager * man )
     connect( man, SIGNAL(ShowGenericLabelText()), this, SLOT(OnShowGenericLabelText()) );
 
     m_sceneManager->PreDisplaySetup();
-    this->PlaceCornerText(); // It was temporarily blocked, seems to work now.
+//        this->PlaceCornerText(); temporarily blocked
 }
 
 void QuadViewWindow::AddBottomWidget( QWidget * w )

--- a/IbisLib/pointrepresentation.cpp
+++ b/IbisLib/pointrepresentation.cpp
@@ -212,6 +212,35 @@ void PointRepresentation::UpdateVisibility()
     }
 }
 
+bool PointRepresentation::CheckVisibility()
+{
+    bool visible = false;
+    // Compute point position in world space
+    vtkTransform * wt = this->GetWorldTransform();
+    PointsObject * parent = PointsObject::SafeDownCast( this->GetParent() );
+    double local[3];
+    parent->GetPointCoordinates( m_pointIndex, local );
+    double world[3];
+    wt->TransformPoint( local, world );
+
+    // check point's visibility in each of 2d views
+    PerViewContainer::iterator it = m_perViewContainer.begin( );
+    while( it != m_perViewContainer.end() )
+    {
+        View * view = (*it).first;
+        if( view->GetType() != THREED_VIEW_TYPE )
+        {
+            bool isInPlane = this->GetManager()->IsInPlane( (VIEWTYPES)view->GetType(), world );
+            if( isInPlane )
+            {
+                visible = true;
+            }
+        }
+        ++it;
+    }
+    return visible;
+}
+
 void PointRepresentation::SetPropertyColor(double color[3])
 {
     m_property->SetColor(color[0], color[1], color[2]);

--- a/IbisLib/pointrepresentation.h
+++ b/IbisLib/pointrepresentation.h
@@ -95,6 +95,8 @@ public:
 
     /** Update the visibility of the point in 2D according to whether it is in a plane. */
     void UpdateVisibility();
+    /** Check visibility of the point in 2D according to whether it is in a plane. */
+    bool CheckVisibility();
 
 protected:
 

--- a/IbisLib/pointsobject.cpp
+++ b/IbisLib/pointsobject.cpp
@@ -391,14 +391,29 @@ vtkPoints * PointsObject::GetPoints()
 void PointsObject::SetSelectedPoint( int index )
 {
     // Set selected point
-    Q_ASSERT( index != InvalidPointIndex && index < m_pointCoordinates->GetNumberOfPoints() );
-    m_selectedPointIndex = index;
+    if ( index != InvalidPointIndex && index < m_pointCoordinates->GetNumberOfPoints() )
+        m_selectedPointIndex = index;
+    else
+        return;
 
     // Update points colors
     UpdatePoints();
 
     emit PointsChanged();
     emit ObjectModified();
+}
+
+void PointsObject::ValidateSelectedPoint()
+{
+    if( m_selectedPointIndex == InvalidPointIndex )
+        return;
+
+    vtkSmartPointer<PointRepresentation> pt = m_pointList.at( m_selectedPointIndex );
+    if( !pt->CheckVisibility() )
+    {
+        m_selectedPointIndex = InvalidPointIndex ;
+        emit ObjectModified();
+    }
 }
 
 void PointsObject::MoveCursorToPoint( int index )

--- a/IbisLib/pointsobject.h
+++ b/IbisLib/pointsobject.h
@@ -179,6 +179,8 @@ public:
     void SetPointCoordinates( int index, double coords[3] );
     /** Set point timestamp - time when point was created. */
     void SetPointTimeStamp( int index, const QString & stamp);
+    /** Check if the selected point is in the current planes. */
+    void ValidateSelectedPoint();
 
 signals:
     void PointAdded();

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -814,7 +814,7 @@ void SceneManager::RemoveObject( SceneObject * object )
 
     SceneObject * parent = object->GetParent();
 
-    if( m_currentObject == object )
+    if( object == SceneObject::SafeDownCast(m_currentObject ) )
     {
         if( parent )
             this->SetCurrentObject(parent);
@@ -826,7 +826,7 @@ void SceneManager::RemoveObject( SceneObject * object )
         emit StartRemovingObject( object->GetParent(), position );
 
     // Set ReferenceDataObject if needed
-    if (object == m_referenceDataObject)
+    if ( object == SceneObject::SafeDownCast(m_referenceDataObject) )
     {
         m_referenceDataObject  = nullptr;
         m_referenceTransform->Identity();

--- a/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.ui
+++ b/IbisPlugins/GPU_VolumeReconstruction/gpu_volumereconstructionwidget.ui
@@ -43,12 +43,12 @@
       <widget class="QCheckBox" name="useMaskCheckBox">
        <property name="maximumSize">
         <size>
-         <width>80</width>
+         <width>120</width>
          <height>16777215</height>
         </size>
        </property>
        <property name="text">
-        <string>Use mask</string>
+        <string>Use Mask</string>
        </property>
       </widget>
      </item>

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -571,6 +571,7 @@ void LandmarkRegistrationObject::UpdateLandmarkTransform( )
 
 void LandmarkRegistrationObject::OnSourcePointsRemoved()
 {
+    disconnect( m_sourcePoints, SIGNAL(RemovingFromScene()), this, SLOT(OnSourcePointsRemoved()) );
     m_sourcePoints = nullptr;
 }
 

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -186,6 +186,7 @@ void LandmarkRegistrationObject::ObjectAboutToBeRemovedFromScene()
     if( m_targetPoints )
         GetManager()->RemoveObject( m_targetPoints );
     disconnect( GetManager(), SIGNAL(CurrentObjectChanged()), this, SLOT(CurrentObjectChanged()));
+    disconnect( GetManager(), SIGNAL(CursorPositionChanged()), this, SLOT(CurrentObjectChanged()) );
 }
 
 void LandmarkRegistrationObject::Export()

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -61,6 +61,7 @@ void LandmarkRegistrationObject::CreateSettingsWidgets( QWidget * parent, QVecto
     if( m_sourcePoints )
     {
         connect( m_sourcePoints, SIGNAL(ObjectModified()), props, SLOT(UpdateUI()) );
+        connect( this, SIGNAL(UpdateSettings()), props, SLOT(UpdateUI()) );
     }
     connect( this, SIGNAL(ObjectModified()), props, SLOT(UpdateUI()) );
     widgets->append(props);
@@ -142,7 +143,7 @@ void LandmarkRegistrationObject::CurrentObjectChanged()
     {
         EnablePicking( true );
         m_sourcePoints->ValidateSelectedPoint();
-        emit ObjectModified();
+        emit UpdateSettings();
     }
     else
         EnablePicking( false );
@@ -176,6 +177,7 @@ void LandmarkRegistrationObject::InternalPostSceneRead()
 void LandmarkRegistrationObject::ObjectAddedToScene()
 {
     connect( GetManager(), SIGNAL(CurrentObjectChanged()), this, SLOT(CurrentObjectChanged()));
+    connect( GetManager(), SIGNAL(CursorPositionChanged()), this, SLOT(CurrentObjectChanged()) );
 }
 
 void LandmarkRegistrationObject::ObjectAboutToBeRemovedFromScene()

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -297,6 +297,15 @@ void LandmarkRegistrationObject::Show()
     m_targetPoints->UpdatePointsVisibility();
 }
 
+void LandmarkRegistrationObject::SetHiddenChildren(SceneObject * parent, bool hide)
+{
+    // LandmarkRegistrationObject has two children, we just show/hide both.
+    m_sourcePoints->SetHidden( hide );
+    m_targetPoints->SetHidden( hide );
+    m_sourcePoints->UpdatePointsVisibility();
+    m_targetPoints->UpdatePointsVisibility();
+}
+
 void LandmarkRegistrationObject::SetSourcePoints( vtkSmartPointer<PointsObject> pts)
 {
     Q_ASSERT( GetManager() );

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -141,6 +141,8 @@ void LandmarkRegistrationObject::CurrentObjectChanged()
     if( GetManager()->GetCurrentObject() == this )
     {
         EnablePicking( true );
+        m_sourcePoints->ValidateSelectedPoint();
+        emit ObjectModified();
     }
     else
         EnablePicking( false );
@@ -292,6 +294,7 @@ void LandmarkRegistrationObject::Hide()
 void LandmarkRegistrationObject::Show()
 {
     m_sourcePoints->SetHidden( false );
+    m_sourcePoints->ValidateSelectedPoint();
     m_targetPoints->SetHidden( false );
     m_sourcePoints->UpdatePointsVisibility();
     m_targetPoints->UpdatePointsVisibility();
@@ -301,6 +304,8 @@ void LandmarkRegistrationObject::SetHiddenChildren(SceneObject * parent, bool hi
 {
     // LandmarkRegistrationObject has two children, we just show/hide both.
     m_sourcePoints->SetHidden( hide );
+    if( !hide )
+        m_sourcePoints->ValidateSelectedPoint();
     m_targetPoints->SetHidden( hide );
     m_sourcePoints->UpdatePointsVisibility();
     m_targetPoints->UpdatePointsVisibility();

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
@@ -67,6 +67,7 @@ public slots:
     void PointAdded( );
     void PointRemoved( int );
     void Update();
+    void OnSourcePointsRemoved();
 
 protected slots:
 

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
@@ -78,6 +78,7 @@ protected:
     virtual void InternalPostSceneRead();
     virtual void Hide();
     virtual void Show();
+    virtual void SetHiddenChildren(SceneObject * parent, bool hide);
 
     void WriteTagFile( const QString & filename, bool saveEnabledOnly = false );
     void WriteXFMFile( const QString & filename );

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.h
@@ -60,6 +60,9 @@ public:
     void SetTargetPointTimeStamp( int index, const QString &stamp );
     void SetTagSize( int tagSize );
 
+signals:
+    void UpdateSettings();
+
 public slots:
     void PointAdded( );
     void PointRemoved( int );

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
@@ -80,6 +80,7 @@ void LandmarkRegistrationObjectSettingsWidget::SetLandmarkRegistrationObject(Lan
         return;
     m_registrationObject = obj;
     m_registrationObject->Register(nullptr);
+    connect( m_registrationObject, SIGNAL(ObjectModified()), this, SLOT(UpdateUI()) );
     this->UpdateUI();
 }
 
@@ -316,9 +317,8 @@ void LandmarkRegistrationObjectSettingsWidget::UpdateUI()
     if( m_registrationObject->GetNumberOfPoints() > 0 )
     {
         int selectedPointIndex = m_registrationObject->GetSourcePoints()->GetSelectedPointIndex();
-        if( selectedPointIndex == PointsObject::InvalidPointIndex  || selectedPointIndex >= m_registrationObject->GetNumberOfPoints() )
-            selectedPointIndex = 0;
-        ui->pointsTreeView->setCurrentIndex( m_model->index( selectedPointIndex, 0 ) );
+        if( selectedPointIndex != PointsObject::InvalidPointIndex  && selectedPointIndex < m_registrationObject->GetNumberOfPoints() )
+            ui->pointsTreeView->setCurrentIndex( m_model->index( selectedPointIndex, 0 ) );
     }
 }
 

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
@@ -80,7 +80,7 @@ void LandmarkRegistrationObjectSettingsWidget::SetLandmarkRegistrationObject(Lan
         return;
     m_registrationObject = obj;
     m_registrationObject->Register(nullptr);
-    connect( m_registrationObject, SIGNAL(ObjectModified()), this, SLOT(UpdateUI()) );
+    connect( m_registrationObject, SIGNAL(UpdateSettings()), this, SLOT(UpdateUI()) );
     this->UpdateUI();
 }
 


### PR DESCRIPTION
* Manage removal of source points.
* Check individual points visibility.
* Validate point selection .
* Corrected scene objects comparison in few places.
* Fixed hiding with children in LandmarkRegistrationObject.

Additionally
* Put back corner annotations in all views as they seem to work now.
* Corrected GPU_VolumeReconstrucionWidget to show full text.