### PR TITLE
LandmarkRegistration bug #473 fix.

### DIFF
--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -861,7 +861,7 @@ void SceneManager::RemoveObject( SceneObject * object )
     // Tell other this object is being removed
     object->RemoveFromScene();
     //at this moment object still exist, we send ObjectRemoved() signal
-    //in order to let other objects to deal with the a still valid object,
+    //in order to let other objects to deal with the still valid object,
     //unregister shoul trigger destruction of the object
     emit ObjectRemoved( objId );
 

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -868,10 +868,10 @@ void SceneManager::RemoveObject( SceneObject * object )
     // remove the object from the global list
     this->AllObjects.removeAt( indexAll );
 
-    object->UnRegister( this );
-
-    if( object->IsListable() )
+     if( object->IsListable() )
         emit FinishRemovingObject();
+
+    object->UnRegister(this); // Unregister may call delete if object->ReferenceCount == 1, then no operation on the object may be done.
 
     ValidatePointerObject();
 }

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -814,7 +814,7 @@ void SceneManager::RemoveObject( SceneObject * object )
 
     SceneObject * parent = object->GetParent();
 
-    if( object == SceneObject::SafeDownCast(m_currentObject ) )
+    if( object == m_currentObject )
     {
         if( parent )
             this->SetCurrentObject(parent);

--- a/IbisLib/scenemanager.cpp
+++ b/IbisLib/scenemanager.cpp
@@ -883,7 +883,8 @@ void SceneManager::ChangeParent( SceneObject * object, SceneObject * newParent, 
 
     emit StartRemovingObject( curParent, position );
     curParent->RemoveChild( object );
-    emit FinishRemovingObject();
+    if( object->IsListable() )
+        emit FinishRemovingObject();
 
     emit StartAddingObject( newParent, newChildIndex );
     newParent->InsertChild( object, newChildIndex );

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -187,9 +187,8 @@ void LandmarkRegistrationObject::ObjectAboutToBeRemovedFromScene()
 {
     disconnect( GetManager(), SIGNAL(CurrentObjectChanged()), this, SLOT(CurrentObjectChanged()));
     disconnect( GetManager(), SIGNAL(CursorPositionChanged()), this, SLOT(CurrentObjectChanged()) );
-    // m_targetPoints is not a child of LandmarkRegistrationObject, it has to be removed explicitly
-    if( m_targetPoints )
-        GetManager()->RemoveObject( m_targetPoints );
+    // m_targetPoints is not a child of LandmarkRegistrationObject, it is removed as a World child
+    m_targetPoints = nullptr;
 }
 
 void LandmarkRegistrationObject::Export()
@@ -573,6 +572,7 @@ void LandmarkRegistrationObject::OnSourcePointsRemoved()
 {
     disconnect( m_sourcePoints, SIGNAL(RemovingFromScene()), this, SLOT(OnSourcePointsRemoved()) );
     m_sourcePoints = nullptr;
+    m_sourcePointsID = SceneManager::InvalidId;
 }
 
 void LandmarkRegistrationObject::Update()

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -307,7 +307,7 @@ void LandmarkRegistrationObject::Show()
 
 void LandmarkRegistrationObject::SetHiddenChildren(SceneObject * parent, bool hide)
 {
-    // LandmarkRegistrationObject has two children, we just show/hide both.
+    // LandmarkRegistrationObject manages two PointsObjects, we just show/hide both.
     m_sourcePoints->SetHidden( hide );
     if( !hide )
         m_sourcePoints->ValidateSelectedPoint();
@@ -570,7 +570,10 @@ void LandmarkRegistrationObject::UpdateLandmarkTransform( )
 
 void LandmarkRegistrationObject::OnSourcePointsRemoved()
 {
-    disconnect( m_sourcePoints, SIGNAL(RemovingFromScene()), this, SLOT(OnSourcePointsRemoved()) );
+    //No callback operation can be done when source points are removed/
+    disconnect( m_sourcePoints );
+    disconnect( this, SIGNAL(UpdateSettings()) );
+    disconnect( this, SIGNAL(ObjectModified()) );
     m_sourcePoints = nullptr;
     m_sourcePointsID = SceneManager::InvalidId;
 }


### PR DESCRIPTION
The crash was caused by trying to access a deleted object. I changed call order in SceneManager::RemoveObjectByID().