### PR TITLE
Fix building of VTK under clang by backporting patch from 9.1

### DIFF
--- a/IbisSuperBuild/IbisDeps/External_VTK.cmake
+++ b/IbisSuperBuild/IbisDeps/External_VTK.cmake
@@ -7,6 +7,7 @@ ExternalProject_Add( ${vtk_name}
     INSTALL_COMMAND ""
     GIT_REPOSITORY "https://github.com/Kitware/VTK.git"
     GIT_TAG v${IBIS_VTK_LONG_VERSION}
+    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/patch/fixlimits.patch
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${external_project_dir}/${vtk_name}/install
                -DCMAKE_OSX_SYSROOT:PATH=${CMAKE_OSX_SYSROOT}
                -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}

--- a/IbisSuperBuild/IbisDeps/patch/fixlimits.patch
+++ b/IbisSuperBuild/IbisDeps/patch/fixlimits.patch
@@ -1,0 +1,63 @@
+From e066c3f4fbbfe7470c6207db0fc3f3952db633cb Mon Sep 17 00:00:00 2001
+From: Mark Olesen <Mark.Olesen@esi-group.com>
+Date: Tue, 9 Feb 2021 15:19:10 +0100
+Subject: [PATCH] COMP: missing includes (clang)
+
+---
+ Common/Core/vtkGenericDataArrayLookupHelper.h   | 1 +
+ Common/DataModel/vtkPiecewiseFunction.cxx       | 1 +
+ Filters/HyperTree/vtkHyperTreeGridThreshold.cxx | 1 +
+ Rendering/Core/vtkColorTransferFunction.cxx     | 1 +
+ 4 files changed, 4 insertions(+)
+
+diff --git a/Common/Core/vtkGenericDataArrayLookupHelper.h b/Common/Core/vtkGenericDataArrayLookupHelper.h
+index ab9d57248f8..202aaa27f4a 100644
+--- a/Common/Core/vtkGenericDataArrayLookupHelper.h
++++ b/Common/Core/vtkGenericDataArrayLookupHelper.h
+@@ -25,6 +25,7 @@
+ #include "vtkIdList.h"
+ #include <algorithm>
+ #include <cmath>
++#include <limits>
+ #include <unordered_map>
+ #include <vector>
+ 
+diff --git a/Common/DataModel/vtkPiecewiseFunction.cxx b/Common/DataModel/vtkPiecewiseFunction.cxx
+index 22eca0bc22e..11086f1dc42 100644
+--- a/Common/DataModel/vtkPiecewiseFunction.cxx
++++ b/Common/DataModel/vtkPiecewiseFunction.cxx
+@@ -22,6 +22,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+diff --git a/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx b/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+index a16bb27fc66..1052192c616 100644
+--- a/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
++++ b/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+@@ -27,6 +27,7 @@
+ #include "vtkHyperTreeGridNonOrientedCursor.h"
+ 
+ #include <cmath>
++#include <limits>
+ 
+ vtkStandardNewMacro(vtkHyperTreeGridThreshold);
+ 
+diff --git a/Rendering/Core/vtkColorTransferFunction.cxx b/Rendering/Core/vtkColorTransferFunction.cxx
+index 55c046b4df7..1be02919ab9 100644
+--- a/Rendering/Core/vtkColorTransferFunction.cxx
++++ b/Rendering/Core/vtkColorTransferFunction.cxx
+@@ -21,6 +21,7 @@
+ #include <algorithm>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
When trying to follow the build instructions on the wiki page, it failed on building while VTK because of the errors:

```
In file included from /home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkGenericDataArray.h:72,
                 from /home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkGenericDataArray.cxx:25:
/home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkGenericDataArrayLookupHelper.h: In function ‘bool detail::isnan(T)’:
/home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkGenericDataArrayLookupHelper.h:52:26: error: ‘numeric_limits’ is not a member of ‘std’
   52 |   return has_NaN<T, std::numeric_limits<T>::has_quiet_NaN>::isnan(x);
      |                          ^~~~~~~~~~~~~~
/home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkGenericDataArrayLookupHelper.h:52:26: error: ‘numeric_limits’ is not a member of ‘std’
/home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkGenericDataArrayLookupHelper.h:52:42: error: template argument 2 is invalid
   52 |   return has_NaN<T, std::numeric_limits<T>::has_quiet_NaN>::isnan(x);
      |                                          ^
In file included from /home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkGenericDataArray.cxx:27:
/home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkDataArrayPrivate.txx: In function ‘bool vtkDataArrayPrivate::detail::isinf(T)’:
/home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkDataArrayPrivate.txx:97:31: error: ‘numeric_limits’ is not a member of ‘std’
   97 |   return has_infinity<T, std::numeric_limits<T>::has_infinity>::isinf(x);
      |                               ^~~~~~~~~~~~~~
/home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkDataArrayPrivate.txx:97:31: error: ‘numeric_limits’ is not a member of ‘std’
/home/driusan/Code/Ibis/build2/IbisDeps/vtk-9.0.1/src/Common/Core/vtkDataArrayPrivate.txx:97:47: error: template argument 2 is invalid
   97 |   return has_infinity<T, std::numeric_limits<T>::has_infinity>::isinf(x);
      |                                               ^
make[5]: *** [Common/Core/CMakeFiles/CommonCore.dir/build.make:95: Common/Core/CMakeFiles/CommonCore.dir/vtkGenericDataArray.cxx.o] Error 1
make[4]: *** [CMakeFiles/Makefile2:3348: Common/Core/CMakeFiles/CommonCore.dir/all] Error 2
make[3]: *** [Makefile:136: all] Error 2
make[2]: *** [IbisDeps/CMakeFiles/vtk-9.0.1.dir/build.make:86: IbisDeps/vtk-9.0.1/stamp/vtk-9.0.1-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:135: IbisDeps/CMakeFiles/vtk-9.0.1.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

This backports the fix from VTK 9.1 at https://gitlab.kitware.com/vtk/vtk/-/commit/e066c3f4fbbfe7470c6207db0fc3f3952db633cb.patch and applies it as a patch so that the build succeeds.