### PR TITLE
fix: center default view position in live window

### DIFF
--- a/IbisPlugins/USAcquisition/doubleviewwidget.cpp
+++ b/IbisPlugins/USAcquisition/doubleviewwidget.cpp
@@ -633,8 +633,8 @@ void SetDefaultView( vtkSmartPointer<vtkImageSlice> actor, vtkSmartPointer<vtkRe
     cam->SetParallelScale(scaley);
     double * prevPos = cam->GetPosition();
     double * prevFocal = cam->GetFocalPoint();
-    cam->SetPosition( scalex, scaley, prevPos[2] );
-    cam->SetFocalPoint( scalex, scaley, prevFocal[2] );
+    cam->SetPosition( diffx, diffy, prevPos[2] );
+    cam->SetFocalPoint( diffx, diffy, prevFocal[2] );
 }
 
 void DoubleViewWidget::SetDefaultViews()


### PR DESCRIPTION
With vtk9, image in live view was not centered.