### PR TITLE
Fix: check if HarwareModule exists before deleting USProbe object

### DIFF
--- a/IbisLib/usprobeobject.cpp
+++ b/IbisLib/usprobeobject.cpp
@@ -151,12 +151,14 @@ void UsProbeObject::SerializeTracked( Serializer * ser )
 
 void UsProbeObject::AddClient()
 {
-    GetHardwareModule()->AddTrackedVideoClient( this );
+    if( IsDrivenByHardware() )
+        GetHardwareModule()->AddTrackedVideoClient( this );
 }
 
 void UsProbeObject::RemoveClient()
 {
-    GetHardwareModule()->RemoveTrackedVideoClient( this );
+    if( IsDrivenByHardware() )
+        GetHardwareModule()->RemoveTrackedVideoClient( this );
 }
 
 void UsProbeObject::ObjectAddedToScene()


### PR DESCRIPTION
Deleting USProbeObject from scene causes Ibis to crash. GetHardwareModule returns a nullptr and is being used to remove the object. This PR makes sure HW module exists before calling RemoveTrackedVideoClient().