### PR TITLE
Fix build with VTK9.1.0

### DIFF
--- a/IbisLib/hardwaremodule.h
+++ b/IbisLib/hardwaremodule.h
@@ -32,7 +32,7 @@ public:
     HardwareModule() {}
     virtual ~HardwareModule() {}
 
-    virtual IbisPluginTypes GetPluginType() VTK_OVERRIDE { return IbisPluginTypeHardwareModule; }
+    virtual IbisPluginTypes GetPluginType() override { return IbisPluginTypeHardwareModule; }
 
     virtual void AddSettingsMenuEntries( QMenu * menu ) {}
     virtual void Init() = 0;

--- a/IbisVTK/vtkQt/vtkQtPiecewiseFunctionWidget.cpp
+++ b/IbisVTK/vtkQt/vtkQtPiecewiseFunctionWidget.cpp
@@ -19,6 +19,7 @@ See Copyright.txt or http://ibisneuronav.org/Copyright.html for details.
 #include <QMouseEvent>
 
 #include <limits>
+#include <cmath>
 
 const int vtkQtPiecewiseFunctionWidget::m_pointRadius = 5;
 


### PR DESCRIPTION
Although not required for the moment...
* VTK_OVERRIDE is deprecated since VTK 9.1.0
* cmath is needed to build against VTK 9.1.0 and newer