### PR TITLE
Add a border around the base colour selection button

### DIFF
--- a/IbisLib/gui/pointcloudobjectsettingsdialog.cpp
+++ b/IbisLib/gui/pointcloudobjectsettingsdialog.cpp
@@ -83,7 +83,7 @@ void PointCloudObjectSettingsDialog::UpdateUI()
     // Update color ui
     double * color = m_object->GetProperty()->GetColor();
     QString styleColor = QString("background-color: rgb(%1,%2,%3);").arg( (int)(color[0] * 255) ).arg( (int)(color[1] * 255) ).arg( (int)(color[2] * 255) );
-    QString style = QString("border-width: 2px; border-style: solid; border-radius: 7;" );
+    QString style = QString("border-width: 2px; border-style: solid; border-radius: 7; border-color: black;" );
     styleColor += style;
     this->changeColorButton->setStyleSheet( styleColor );
 

--- a/IbisLib/gui/polydataobjectsettingsdialog.cpp
+++ b/IbisLib/gui/polydataobjectsettingsdialog.cpp
@@ -101,7 +101,7 @@ void PolyDataObjectSettingsDialog::UpdateUI()
     // Update color ui
     double * color = m_object->GetColor();
     QString styleColor = QString("background-color: rgb(%1,%2,%3);").arg( (int)(color[0] * 255) ).arg( (int)(color[1] * 255) ).arg( (int)(color[2] * 255) );
-    QString style = QString("border-width: 2px; border-style: solid; border-radius: 7;border-color: black;" );
+    QString style = QString("border-width: 2px; border-style: solid; border-radius: 7; border-color: black;" );
     styleColor += style;
     this->changeColorButton->setStyleSheet( styleColor );
     this->changeColorButton->setFlat( false );

--- a/IbisLib/gui/tractogramobjectsettingsdialog.cpp
+++ b/IbisLib/gui/tractogramobjectsettingsdialog.cpp
@@ -104,7 +104,7 @@ void TractogramObjectSettingsDialog::UpdateUI()
     // Update color ui
     double * color = m_object->GetColor();
     QString styleColor = QString("background-color: rgb(%1,%2,%3);").arg( (int)(color[0] * 255) ).arg( (int)(color[1] * 255) ).arg( (int)(color[2] * 255) );
-    QString style = QString("border-width: 2px; border-style: solid; border-radius: 7;" );
+    QString style = QString("border-width: 2px; border-style: solid; border-radius: 7; border-color: black;" );
     styleColor += style;
     this->changeColorButton->setStyleSheet( styleColor );
 


### PR DESCRIPTION
This avoids the problem of the button dissapearing when the base the colour is the same as the UI background.