### PR TITLE
Fix vtk render refresh rate

### DIFF
--- a/IbisLib/gui/quadviewwindow.cpp
+++ b/IbisLib/gui/quadviewwindow.cpp
@@ -203,7 +203,7 @@ void QuadViewWindow::SetSceneManager( SceneManager * man )
     connect( man, SIGNAL(ShowGenericLabelText()), this, SLOT(OnShowGenericLabelText()) );
 
     m_sceneManager->PreDisplaySetup();
-//        this->PlaceCornerText(); temporarily blocked
+    //this->PlaceCornerText(); //temporarily blocked
 }
 
 void QuadViewWindow::AddBottomWidget( QWidget * w )

--- a/IbisLib/view.h
+++ b/IbisLib/view.h
@@ -170,6 +170,8 @@ public slots:
     /** Notify the view that something it contains needs render. The view is then
      *  going to emit a Modified event. */
     void NotifyNeedRender();
+    /** Set enable render to true to refresh rendering */
+    void EnableRendering();
     /** Update camera transform when the reference transform is modified. */
     void ReferenceTransformChanged();
 


### PR DESCRIPTION
Set call to VTK render to match IbisClockTick(). This reduces the number of unnecessary calls to render() which can affect performance.