### PR TITLE
Restrict Superbuild CMake to single configuration

### DIFF
--- a/IbisSuperBuild/CMakeLists.txt
+++ b/IbisSuperBuild/CMakeLists.txt
@@ -1,6 +1,27 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required( VERSION 3.5 )
 set( project_name IbisSuperBuild )
+
 project( ${project_name} )
+
+# Set build type:
+# Ibis does not currently support multi-configuration and defaults to Release when config unspecified
+if( WIN32 )
+    if( "${CMAKE_CONFIGURATION_TYPES}" MATCHES ".*;.*" )
+        set( CMAKE_CONFIGURATION_TYPES "Release" CACHE STRING "Build type" FORCE )
+        message( STATUS "Multi-configuration is replaced with default build type" )
+    endif()
+    set_property( CACHE CMAKE_CONFIGURATION_TYPES PROPERTY STRINGS Release Debug )
+    # For OpenCV build
+    set( CMAKE_BUILD_TYPE "${CMAKE_CONFIGURATION_TYPES}" )
+    message( STATUS "Building with configuration: ${CMAKE_CONFIGURATION_TYPES}" )
+else()
+    if( CMAKE_BUILD_TYPE STREQUAL "" )
+        set( CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE )
+        message( STATUS "Unspecified build type defaults to Release" )
+    endif()
+    set_property( CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release Debug )
+    message( STATUS "Building with configuration: ${CMAKE_BUILD_TYPE}" )
+endif()
 
 # Find Qt5
 find_package( Qt5 COMPONENTS Widgets REQUIRED )
@@ -56,6 +77,7 @@ ExternalProject_Add(
                -DCMAKE_OSX_SYSROOT:PATH=${CMAKE_OSX_SYSROOT}
                -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
                -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+               -DCMAKE_CONFIGURATION_TYPES:STRING=${CMAKE_CONFIGURATION_TYPES}
                -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
                -DCMAKE_CONFIGURATION_TYPES:STRING=${CMAKE_CONFIGURATION_TYPES}
                -DQt5_DIR:PATH=${Qt5_DIR}


### PR DESCRIPTION
On Windows the default value for CMAKE_CONFIGURATION_TYPES is Debug;Release;MinSizeRel;RelWithDebInfo, which causes problems with WinDeployQt, as outlined in #267. The Ibis Wiki was already requesting Windows users to set a single configuration, but it wasn't enforced in the CMakeLists, which led to failed builds when the user didn't comply with the build instructions. This commits reconciles the wiki instructions with the CMakeLists. It makes the build process more straightforward and intuitiuve. Specifically:

* On the first run, the configuration defaults to Release

* The cache is only allowed Debug and Release (single config)

* The CMAKE_BUILD_TYPE variable is automatically set on Windows to match the CMAKE_CONFIGURATION_TYPES variable, to enable OpenCV to build without requiring the user to set it directly