### PR TITLE
Fix picking points outside of volume

### DIFF
--- a/IbisLib/pointsobject.cpp
+++ b/IbisLib/pointsobject.cpp
@@ -393,18 +393,6 @@ void PointsObject::UnselectAllPoints()
     emit ObjectModified();
 }
 
-void PointsObject::ValidateSelectedPoint()
-{
-    if( m_selectedPointIndex == InvalidPointIndex ) return;
-
-    vtkSmartPointer<PointRepresentation> pt = m_pointList.at( m_selectedPointIndex );
-    if( !pt->CheckVisibility() )
-    {
-        m_selectedPointIndex = InvalidPointIndex;
-        emit ObjectModified();
-    }
-}
-
 void PointsObject::MoveCursorToPoint( int index )
 {
     Q_ASSERT( index != InvalidPointIndex && index < m_pointCoordinates->GetNumberOfPoints() );

--- a/IbisLib/pointsobject.h
+++ b/IbisLib/pointsobject.h
@@ -180,8 +180,6 @@ public:
     void SetPointCoordinates( int index, double coords[3] );
     /** Set point timestamp - time when point was created. */
     void SetPointTimeStamp( int index, const QString & stamp );
-    /** Check if the selected point is in the current planes. */
-    void ValidateSelectedPoint();
 
 signals:
     void PointAdded();

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobject.cpp
@@ -140,7 +140,6 @@ void LandmarkRegistrationObject::CurrentObjectChanged()
         if( GetManager()->GetCurrentObject() == SceneObject::SafeDownCast( this ) )
         {
             EnablePicking( true );
-            m_sourcePoints->ValidateSelectedPoint();
             emit UpdateSettings();
         }
         else
@@ -297,7 +296,6 @@ void LandmarkRegistrationObject::Hide()
 void LandmarkRegistrationObject::Show()
 {
     m_sourcePoints->SetHidden( false );
-    m_sourcePoints->ValidateSelectedPoint();
     m_targetPoints->SetHidden( false );
     m_sourcePoints->UpdatePointsVisibility();
     m_targetPoints->UpdatePointsVisibility();
@@ -307,7 +305,6 @@ void LandmarkRegistrationObject::SetHiddenChildren( SceneObject * parent, bool h
 {
     // LandmarkRegistrationObject manages two PointsObjects, we just show/hide both.
     m_sourcePoints->SetHidden( hide );
-    if( !hide ) m_sourcePoints->ValidateSelectedPoint();
     m_targetPoints->SetHidden( hide );
     m_sourcePoints->UpdatePointsVisibility();
     m_targetPoints->UpdatePointsVisibility();

--- a/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
+++ b/IbisPlugins/LandmarkRegistrationObject/landmarkregistrationobjectsettingswidget.cpp
@@ -91,7 +91,10 @@ void LandmarkRegistrationObjectSettingsWidget::on_capturePushButton_clicked()
 {
     Q_ASSERT( m_registrationObject );
     int index = ui->pointsTreeView->currentIndex().row();
-    Q_ASSERT( index >= 0 && index < m_registrationObject->GetNumberOfPoints() );
+    if( ! (index >= 0 && index < m_registrationObject->GetNumberOfPoints()) ){
+        std::cerr << "No point selected, nothing was captured." << std::endl;
+        return;
+    }
 
     Q_ASSERT( m_registrationObject->GetManager() );
     PointerObject * pointer = m_registrationObject->GetManager()->GetNavigationPointerObject();


### PR DESCRIPTION
* When handling LandmarkRegistrationObject points outside of the main volume, no point would get selected in the widget after a capture and a subsequent capture would crash the app. This behaviour is undesired. While it may be rare to handle LandmarkRegistrationObject points not associated with a loaded volume, the case can still arise.
* Current solution: Validation that points are within the bounds of the volume aren't enforced anymore and in the event that the user tries to capture when no point is selected, we simply move on without capturing anything and display an error message.